### PR TITLE
feature: cli pending rejection, two party balance endpoint

### DIFF
--- a/lndr-backend/src/Lndr/EthInterface.hs
+++ b/lndr-backend/src/Lndr/EthInterface.hs
@@ -118,26 +118,12 @@ finalizeTransaction sig1 sig2 r@(CreditRecord creditor debtor amount memo _) = d
                             encodedMemo
 
 
-lndrLogs :: Provider a => Web3 a [IssueCreditLog]
-lndrLogs = rights . fmap interpretUcacLog <$>
+lndrLogs :: Provider a => Maybe Address -> Maybe Address -> Web3 a [IssueCreditLog]
+lndrLogs p1M p2M = rights . fmap interpretUcacLog <$>
     Eth.getLogs (Filter (Just cpAddr)
-                        (Just [Just issueCreditEvent, Just ucacId])
-                        (Just "0x0") -- start from block 0
-                        Nothing)
-
-
-lndrDebitLogs :: Provider a => Address -> Web3 a [IssueCreditLog]
-lndrDebitLogs addr = rights . fmap interpretUcacLog <$>
-    Eth.getLogs (Filter (Just cpAddr)
-                        (Just [Just issueCreditEvent, Just ucacId, Nothing, Just (addressToBytes32 addr)])
-                        (Just "0x0") -- start from block 0
-                        Nothing)
-
-
-lndrCreditLogs :: Provider a => Address -> Web3 a [IssueCreditLog]
-lndrCreditLogs addr = rights . fmap interpretUcacLog <$>
-    Eth.getLogs (Filter (Just cpAddr)
-                        (Just [Just issueCreditEvent, Just ucacId, Just (addressToBytes32 addr)])
+                        (Just [ Just issueCreditEvent, Just ucacId
+                              , addressToBytes32 <$> p1M
+                              , addressToBytes32 <$> p2M ])
                         (Just "0x0") -- start from block 0
                         Nothing)
 

--- a/lndr-backend/src/Lndr/EthInterface.hs
+++ b/lndr-backend/src/Lndr/EthInterface.hs
@@ -167,15 +167,6 @@ integerToHex x = T.append "0x" strRep
     where strRep = alignR . T.pack $ showHex x ""
 
 
-hashPrefixedMessage :: String -> Text -> Text
-hashPrefixedMessage pre message = T.pack . show $ keccakDigest
-    where messageBytes = fst . BS16.decode . T.encodeUtf8 $ message
-          prefix = T.encodeUtf8 . T.pack $
-            pre ++ show (B.length messageBytes)
-          keccakDigest :: C.Digest C.Keccak_256
-          keccakDigest = C.hash (prefix `B.append` messageBytes)
-
-
 align :: Text -> (Text, Text)
 align v = (v <> zeros, zeros <> v)
   where zerosLen = 64 - (T.length v `mod` 64)

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -13,6 +13,7 @@ module Lndr.Handler (
     , nonceHandler
     , counterpartiesHandler
     , balanceHandler
+    , twoPartyBalanceHandler
 
       -- * Friend Handlers
     , nickHandler

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -20,7 +20,6 @@ import           Servant.API
 import qualified STMContainers.Map as Map
 
 
--- submit a signed message consisting of "REJECT + CreditRecord HASH"
 rejectHandler :: RejectRecord -> LndrHandler NoContent
 rejectHandler(RejectRecord sig hash) = do
     pendingMapping <- pendingMap <$> ask
@@ -31,7 +30,6 @@ rejectHandler(RejectRecord sig hash) = do
             liftIO . atomically $ Map.delete hash pendingMapping
             let counterparty = if creditor == submitter then debtor else creditor
             -- recover address from sig
-            let message = hashPrefixedMessage "REJECT" hash
             let signer = EU.ecrecover (stripHexPrefix sig) $ EU.hashPersonalMessage hash
             case signer of
                 Left err -> throwError $ err404 {errBody = "unable to recover addr from sig"}

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -32,10 +32,10 @@ rejectHandler(RejectRecord sig hash) = do
             -- recover address from sig
             let signer = EU.ecrecover (stripHexPrefix sig) $ EU.hashPersonalMessage hash
             case signer of
-                Left err -> throwError $ err404 {errBody = "unable to recover addr from sig"}
+                Left err -> throwError $ err400 {errBody = "unable to recover addr from sig"}
                 Right addr -> if textToAddress addr == counterparty
                                     then return ()
-                                    else throwError $ err404 {errBody = "bad rejection sig"}
+                                    else throwError $ err400 {errBody = "bad rejection sig"}
 
             -- verify that address is counterparty
             liftIO . atomically $ Map.delete hash pendingMapping

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -50,6 +50,7 @@ type LndrAPI =
                          :> PostNoContent '[JSON] NoContent
    :<|> "counterparties" :> Capture "user" Address :> Get '[JSON] [Address]
    :<|> "balance" :> Capture "user" Address :> Get '[JSON] Integer
+   :<|> "balance" :> Capture "p1" Address :> Capture "p2" Address :> Get '[JSON] Integer
    :<|> "docs" :> Raw
 
 
@@ -81,6 +82,7 @@ server = transactionsHandler
     :<|> removeFriendsHandler
     :<|> counterpartiesHandler
     :<|> balanceHandler
+    :<|> twoPartyBalanceHandler
     :<|> Tagged serveDocs
     where serveDocs _ respond =
             respond $ responseLBS ok200 [plain] docsBS

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -108,6 +108,7 @@ getNick url userAddr = do
         Left a -> "nick not found"
         Right b -> b
 
+
 addFriend :: String -> Address -> Address -> IO Int
 addFriend url userAddr addr = do
     initReq <- HTTP.parseRequest $ url ++ "/add_friends/" ++ show userAddr

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -26,6 +26,7 @@ import qualified Text.Pretty.Simple as Pr
 
 data LndrCmd = Transactions
              | Pending
+             | RejectPending
              | Lend { friend :: Text
                     , amount :: Integer
                     , memo :: Text
@@ -121,11 +122,18 @@ getFriends url userAddr = do
     HTTP.getResponseBody <$> HTTP.httpJSON req
 
 
-getInfo :: String -> Text -> IO (Address, Text, [NickInfo])
+getBalance :: String -> Address -> IO Integer
+getBalance url userAddr = do
+    req <- HTTP.parseRequest $ url ++ "/balance/" ++ show userAddr
+    HTTP.getResponseBody <$> HTTP.httpJSON req
+
+
+getInfo :: String -> Text -> IO (Address, Text, Integer, [NickInfo])
 getInfo url userAddr = do
     nick <- getNick url address
+    balance <- getBalance url address
     friends <- getFriends url address
-    return (address, nick, friends)
+    return (address, nick, balance, friends)
     where address = textToAddress userAddr
 
 


### PR DESCRIPTION
- testing /reject endpoint with CLI
   + slightly updated signing logic of rejection. This was done in preparation for the addition of signing logic to several of the friend endpoints.
- adding /balance/:user1/:user2 endpoint
- improving log scanning functions