### PR TITLE
Updating gas price in config to safelow if possible.

### DIFF
--- a/lndr-backend/lndr-backend.cabal
+++ b/lndr-backend/lndr-backend.cabal
@@ -33,6 +33,7 @@ library
                      , ethereumhs-util
                      , filepath
                      , hashable
+                     , http-conduit
                      , http-types
                      , listsafe
                      , list-t

--- a/lndr-backend/src/Lndr/EthInterface.hs
+++ b/lndr-backend/src/Lndr/EthInterface.hs
@@ -33,6 +33,7 @@ import qualified Network.Ethereum.Web3.Address as Addr
 import qualified Network.Ethereum.Web3.Eth as Eth
 import           Network.Ethereum.Web3.TH
 import           Network.Ethereum.Web3.Types
+import qualified Network.HTTP.Simple as HTTP
 import           Numeric (readHex, showHex)
 import           Prelude hiding (lookup, (!!))
 import           System.FilePath
@@ -107,6 +108,14 @@ hashCreditLog (IssueCreditLog ucac creditor debtor amount nonce _) =
                                          , integerToHex nonce
                                          ]
                 in EU.hashText message
+
+
+safelowUpdate :: ServerConfig -> IO ServerConfig
+safelowUpdate config = do
+    req <- HTTP.parseRequest "https://ethgasstation.info/json/ethgasAPI.json"
+    gasStationResponse <- HTTP.getResponseBody <$> HTTP.httpJSON req
+    let lastestSafeLow = ceiling $ 100000000 * safeLow gasStationResponse
+    return $ config { gasPrice = lastestSafeLow }
 
 
 finalizeTransaction :: ServerConfig -> Text -> Text -> CreditRecord

--- a/lndr-backend/src/Lndr/EthInterface.hs
+++ b/lndr-backend/src/Lndr/EthInterface.hs
@@ -116,10 +116,12 @@ safelowUpdate :: ServerConfig -> TVar ServerConfig -> IO ServerConfig
 safelowUpdate config configTVar = do
     req <- HTTP.parseRequest "https://ethgasstation.info/json/ethgasAPI.json"
     gasStationResponse <- HTTP.getResponseBody <$> HTTP.httpJSON req
-    let lastestSafeLow = ceiling $ 100000000 * safeLow gasStationResponse
+    let lastestSafeLow = ceiling $ safeLowScaling * safeLow gasStationResponse
         updatedConfg = config { gasPrice = lastestSafeLow }
     liftIO . atomically . modifyTVar configTVar $ const updatedConfg
     return updatedConfg
+    where
+        safeLowScaling = 100000000 -- eth gas station returns prices in DeciGigaWei
 
 
 finalizeTransaction :: ServerConfig -> Text -> Text -> CreditRecord

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -107,7 +107,7 @@ submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo
                                             else (signature signedRecord, signature storedRecord)
 
             -- update gas price to latest safelow value
-            updatedConfig <- safelowUpdate config
+            updatedConfig <- safelowUpdate config configTVar
 
             finalizeTransaction updatedConfig creditorSig debtorSig storedRecord
 

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -106,7 +106,10 @@ submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo
                                             then (signature storedRecord, signature signedRecord)
                                             else (signature signedRecord, signature storedRecord)
 
-            finalizeTransaction config creditorSig debtorSig storedRecord
+            -- update gas price to latest safelow value
+            updatedConfig <- safelowUpdate config
+
+            finalizeTransaction updatedConfig creditorSig debtorSig storedRecord
 
             -- saving transaction record
             liftIO . withResource pool $ Db.insertCredit creditorSig debtorSig storedRecord

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -12,6 +12,7 @@ module Lndr.Types
     , IssueCreditLog(IssueCreditLog, ucac)
     , RejectRecord(RejectRecord)
     , Nonce(..)
+    , GasStationResponse(..)
     ) where
 
 import           Control.Concurrent.STM.TVar
@@ -92,3 +93,8 @@ data ServerConfig = ServerConfig { lndrUcacAddr :: !Address
 data ServerState = ServerState { dbConnectionPool :: Pool Connection
                                , serverConfig :: TVar ServerConfig
                                }
+
+data GasStationResponse = GasStationResponse { safeLow :: Double
+                                             , safeLowWait :: Double
+                                             } deriving Show
+$(deriveJSON defaultOptions ''GasStationResponse)


### PR DESCRIPTION
fixes #53.

Just before submitting a tx to the blockchain, try to update gas price to current safelow value on https://ethgasstation.info/. If http call fails, default to last value stored in server config.

This change is a little hasty because it had to be included in tonight's server release.