### PR TITLE
making resubmit more logical

### DIFF
--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -86,9 +86,9 @@ instance ToCapture (Capture "nick" Text) where
   toCapture _ =
     DocCapture "nick" "the nickname to be associated with a particular address"
 
-instance ToCapture (Capture "id" Integer) where
+instance ToCapture (Capture "hash" Text) where
   toCapture _ =
-    DocCapture "id" "the amount by which to identify a credit record among candidates for resubmission"
+    DocCapture "hash" "the hash by which to identify a credit record among candidates for resubmission"
 
 instance ToParam (QueryParam "user" Address) where
   toParam _ =

--- a/lndr-backend/src/Lndr/EthInterface.hs
+++ b/lndr-backend/src/Lndr/EthInterface.hs
@@ -91,8 +91,8 @@ decomposeSig sig = (sigR, sigS, sigV)
 [abiFrom|data/CreditProtocol.abi|]
 
 
-hashCreditRecord :: forall b. Provider b => ServerConfig -> Nonce -> CreditRecord -> Web3 b Text
-hashCreditRecord config nonce (CreditRecord creditor debtor amount _ _ _ _ _) = do
+hashCreditRecord :: ServerConfig -> Nonce -> CreditRecord -> Text
+hashCreditRecord config nonce (CreditRecord creditor debtor amount _ _ _ _ _) =
                 let message = T.concat $
                       stripHexPrefix <$> [ Addr.toText (lndrUcacAddr config)
                                          , Addr.toText creditor
@@ -100,7 +100,7 @@ hashCreditRecord config nonce (CreditRecord creditor debtor amount _ _ _ _ _) = 
                                          , integerToHex amount
                                          , integerToHex $ unNonce nonce
                                          ]
-                return $ EU.hashText message
+                in EU.hashText message
 
 
 hashCreditLog :: IssueCreditLog -> Text

--- a/lndr-backend/src/Lndr/Handler/Admin.hs
+++ b/lndr-backend/src/Lndr/Handler/Admin.hs
@@ -4,6 +4,7 @@ import           Control.Concurrent.STM
 import           Control.Monad.Reader
 import           Data.List ((\\), find)
 import           Data.Pool (withResource)
+import           Data.Text (Text)
 import qualified Lndr.Db as Db
 import           Lndr.Handler.Types
 import           Lndr.EthInterface
@@ -36,11 +37,11 @@ unsubmittedHandler = do
     return $ (setUcac (lndrUcacAddr config) <$> dbCredits) \\ blockchainCredits
 
 
-resubmitHandler :: Integer -> LndrHandler NoContent
-resubmitHandler txAmount = do
+resubmitHandler :: Text -> LndrHandler NoContent
+resubmitHandler txHash = do
     (ServerState pool configTVar) <- ask
     txs <- unsubmittedHandler
-    let creditToResubmitM = find (\x -> amount x == txAmount) txs
+    let creditToResubmitM = find ((== txHash) . hashCreditLog) txs
     case creditToResubmitM of
         Just creditLog -> do
             config <- liftIO . atomically $ readTVar configTVar

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -80,7 +80,7 @@ submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo
     (ServerState pool configTVar) <- ask
     config <- liftIO . atomically $ readTVar configTVar
     nonce <- liftIO . withResource pool $ Db.twoPartyNonce creditor debtor
-    hash <- lndrWeb3 $ hashCreditRecord config nonce signedRecord
+    let hash = hashCreditRecord config nonce signedRecord
 
     unless (T.length memo <= 32) $
         throwError (err400 {errBody = "Memo too long. Memos must be no longer than 32 characters."})

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -60,7 +60,7 @@ type LndrAPI =
    :<|> "gas_price" :> Get '[JSON] Integer
    :<|> "gas_price" :> ReqBody '[JSON] Integer :> PutNoContent '[JSON] NoContent
    :<|> "unsubmitted" :> Get '[JSON] [IssueCreditLog]
-   :<|> "resubmit" :> Capture "id" Integer :> PostNoContent '[JSON] NoContent
+   :<|> "resubmit" :> Capture "hash" Text :> PostNoContent '[JSON] NoContent
    :<|> "docs" :> Raw
 
 


### PR DESCRIPTION
fixes #61 

- unsubmitted CreditRecords are selectable by hash now
- `hashCreditRecord` no longer needlessly in the `Web3` type.