### PR TITLE
urban airship registration & testing

### DIFF
--- a/lndr-backend/README.md
+++ b/lndr-backend/README.md
@@ -624,6 +624,60 @@ Clients must supply the following data
 [{"creditor":"0x11edd217a875063583dd1b638d16810c5d34d54b","debtor":"0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb","amount":69,"memo":"test memo","submitter":"0x11edd217a875063583dd1b638d16810c5d34d54b","nonce":0,"hash":"0x4358c649de5746c91673378dd4c40a78feda715166913e09ded45343ff76841c","signature":"0x457b0db63b83199f305ef29ba2d7678820806d98abbe3f6aafe015957ecfc5892368b4432869830456c335ade4f561603499d0216cda3af7b6b6cadf6f273c101b"},{"creditor":"0x11edd217a875063583dd1b638d16810c5d34d54b","debtor":"0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb","amount":69,"memo":"test memo","submitter":"0x11edd217a875063583dd1b638d16810c5d34d54b","nonce":0,"hash":"0x4358c649de5746c91673378dd4c40a78feda715166913e09ded45343ff76841c","signature":"0x457b0db63b83199f305ef29ba2d7678820806d98abbe3f6aafe015957ecfc5892368b4432869830456c335ade4f561603499d0216cda3af7b6b6cadf6f273c101b"}]
 ```
 
+## POST /register_push/:user
+
+#### Authentication
+
+
+
+Clients must supply the following data
+
+
+#### Captures:
+
+- *user*: the address of the user whose friends will be returned
+
+#### Request:
+
+- Supported content types are:
+
+    - `application/json;charset=utf-8`
+    - `application/json`
+
+- Example (): `application/json;charset=utf-8`
+
+```javascript
+{"channelID":"31279004-103e-4ba8-b4bf-65eb3eb81859","platform":"ios"}
+```
+
+- Example (): `application/json`
+
+```javascript
+{"channelID":"31279004-103e-4ba8-b4bf-65eb3eb81859","platform":"ios"}
+```
+
+#### Response:
+
+- Status code 204
+- Headers: []
+
+- Supported content types are:
+
+    - `application/json;charset=utf-8`
+    - `application/json`
+
+-
+
+```javascript
+
+```
+
+-
+
+```javascript
+
+```
+
 ## POST /reject
 
 #### Authentication

--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -34,6 +34,6 @@ CREATE TABLE nicknames (
 
 CREATE TABLE push_data (
     address     CHAR(40) PRIMARY KEY,
-    channel     TEXT UNIQUE,
-    platfor     TEXT
+    channel_id  TEXT UNIQUE,
+    platform    TEXT
 );

--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -31,3 +31,9 @@ CREATE TABLE nicknames (
     address     CHAR(40) PRIMARY KEY,
     nickname    TEXT UNIQUE
 );
+
+CREATE TABLE push_data (
+    address     CHAR(40) PRIMARY KEY,
+    channel     TEXT UNIQUE,
+    platfor     TEXT
+);

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -72,8 +72,8 @@ lookupNick addr conn = listToMaybe . fmap fromOnly <$>
 
 
 lookupAddresByNick :: Text -> Connection -> IO [NickInfo]
-lookupAddresByNick nick conn = fmap ((`NickInfo` nick) . fromOnly) <$>
-    (query conn "SELECT address FROM nicknames WHERE nickname LIKE ? LIMIT 10" (Only $ T.append nick "%") :: IO [Only Address])
+lookupAddresByNick nick conn = fmap (uncurry NickInfo) <$>
+    (query conn "SELECT (address, nickname) FROM nicknames WHERE nickname LIKE ? LIMIT 10" (Only $ T.append nick "%") :: IO [(Address, Text)])
 
 -- friendships table manipulations
 

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -174,7 +174,7 @@ twoPartyNonce addr counterparty conn = do
 
 insertPushDatum :: Address -> Text -> Text -> Connection -> IO Int
 insertPushDatum addr channelID platform conn = fromIntegral <$>
-    execute conn "INSERT INTO push_data (address, channelID, platform) VALUES (?,?,?) ON CONFLICT (address) DO UPDATE SET channel = EXCLUDED.channel" (addr, channelID, platform)
+    execute conn "INSERT INTO push_data (address, channel_id, platform) VALUES (?,?,?) ON CONFLICT (address) DO UPDATE SET (channel_id, platform) = (EXCLUDED.channel_id, EXCLUDED.platform)" (addr, channelID, platform)
 
 
 creditRecordToPendingTuple :: CreditRecord

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -5,7 +5,8 @@ module Lndr.Db (
     -- * 'nicknames' table functions
       insertNick
     , lookupNick
-    , lookupAddresByNick
+    , lookupAddressByNick
+    , lookupAddressesByFuzzyNick
 
     -- * 'friendships' table functions
     , addFriends
@@ -71,9 +72,16 @@ lookupNick addr conn = listToMaybe . fmap fromOnly <$>
     (query conn "SELECT nickname FROM nicknames WHERE address = ?" (Only addr) :: IO [Only Text])
 
 
-lookupAddresByNick :: Text -> Connection -> IO [NickInfo]
-lookupAddresByNick nick conn = fmap (uncurry NickInfo) <$>
-    (query conn "SELECT (address, nickname) FROM nicknames WHERE nickname LIKE ? LIMIT 10" (Only $ T.append nick "%") :: IO [(Address, Text)])
+-- TODO update this to return a maybe
+lookupAddressByNick :: Text -> Connection -> IO [NickInfo]
+lookupAddressByNick nick conn = fmap (uncurry NickInfo) <$>
+    (query conn "SELECT address, nickname FROM nicknames WHERE nickname = ?" (Only nick) :: IO [(Address, Text)])
+
+
+lookupAddressesByFuzzyNick :: Text -> Connection -> IO [NickInfo]
+lookupAddressesByFuzzyNick nick conn = fmap (uncurry NickInfo) <$>
+    (query conn "SELECT address, nickname FROM nicknames WHERE nickname LIKE ? LIMIT 10" (Only $ T.append nick "%") :: IO [(Address, Text)])
+
 
 -- friendships table manipulations
 

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -30,6 +30,9 @@ module Lndr.Db (
     , userBalance
     , twoPartyBalance
     , twoPartyNonce
+
+    -- * 'push_data' table functions
+    , insertPushDatum
     ) where
 
 
@@ -167,6 +170,11 @@ twoPartyNonce :: Address -> Address -> Connection -> IO Nonce
 twoPartyNonce addr counterparty conn = do
     [Only nonce] <- query conn "SELECT COALESCE(MAX(nonce) + 1, 0) FROM verified_credits WHERE (creditor = ? AND debtor = ?) OR (creditor = ? AND debtor = ?)" (addr, counterparty, counterparty, addr) :: IO [Only Scientific]
     return . Nonce . floor $ nonce
+
+
+insertPushDatum :: Address -> Text -> Text -> Connection -> IO Int
+insertPushDatum addr channelID platform conn = fromIntegral <$>
+    execute conn "INSERT INTO push_data (address, channelID, platform) VALUES (?,?,?) ON CONFLICT (address) DO UPDATE SET channel = EXCLUDED.channel" (addr, channelID, platform)
 
 
 creditRecordToPendingTuple :: CreditRecord

--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -54,8 +54,8 @@ instance ToSample IssueCreditLog where
 instance ToSample Address where
     toSamples _ = singleSample "0x11edd217a875063583dd1b638d16810c5d34d54b"
 
-instance ToSample () where
-    toSamples _ = singleSample ()
+instance ToSample PushRequest where
+    toSamples _ = singleSample $ PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios"
 
 instance ToSample Text where
     toSamples _ = singleSample "aupiff"

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -29,6 +29,7 @@ module Lndr.Handler (
     , setGasPriceHandler
     , unsubmittedHandler
     , resubmitHandler
+    , registerPushHandler
     ) where
 
 import           Lndr.Handler.Admin

--- a/lndr-backend/src/Lndr/Handler/Admin.hs
+++ b/lndr-backend/src/Lndr/Handler/Admin.hs
@@ -52,3 +52,10 @@ resubmitHandler txHash = do
                 Nothing               -> pure ()
         Nothing -> pure ()
     pure NoContent
+
+registerPushHandler :: Address -> PushRequest -> LndrHandler NoContent
+registerPushHandler addr (PushRequest channelID platform) = do
+    -- TODO verify signature
+    pool <- dbConnectionPool <$> ask
+    liftIO . withResource pool $ Db.insertPushDatum addr channelID platform
+    return NoContent

--- a/lndr-backend/src/Lndr/Handler/Friend.hs
+++ b/lndr-backend/src/Lndr/Handler/Friend.hs
@@ -30,13 +30,13 @@ nickLookupHandler addr = do
 nickSearchHandler :: Text -> LndrHandler [NickInfo]
 nickSearchHandler nick = do
     pool <- dbConnectionPool <$> ask
-    liftIO . withResource pool . Db.lookupAddresByNick $ T.toLower nick
+    liftIO . withResource pool . Db.lookupAddressesByFuzzyNick $ T.toLower nick
 
 
 nickTakenHandler :: Text -> LndrHandler Bool
 nickTakenHandler nick = do
     pool <- dbConnectionPool <$> ask
-    liftIO . fmap (not . null) . withResource pool . Db.lookupAddresByNick $ T.toLower nick
+    liftIO . fmap (not . null) . withResource pool . Db.lookupAddressByNick $ T.toLower nick
 
 
 friendHandler :: Address -> LndrHandler [NickInfo]

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -61,6 +61,9 @@ type LndrAPI =
    :<|> "gas_price" :> ReqBody '[JSON] Integer :> PutNoContent '[JSON] NoContent
    :<|> "unsubmitted" :> Get '[JSON] [IssueCreditLog]
    :<|> "resubmit" :> Capture "hash" Text :> PostNoContent '[JSON] NoContent
+   :<|> "register_push" :> Capture "user" Address
+                        :> ReqBody '[JSON] PushRequest
+                        :> PostNoContent '[JSON] NoContent
    :<|> "docs" :> Raw
 
 
@@ -97,6 +100,7 @@ server = transactionsHandler
     :<|> setGasPriceHandler
     :<|> unsubmittedHandler
     :<|> resubmitHandler
+    :<|> registerPushHandler
     :<|> Tagged serveDocs
     where serveDocs _ respond =
             respond $ responseLBS ok200 [plain] docsBS

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -77,7 +77,7 @@ $(deriveJSON defaultOptions ''NickRequest)
 
 data NickInfo = NickInfo { addr :: Address
                          , nick :: Text
-                         } deriving (Show, Generic)
+                         } deriving (Show, Eq, Generic)
 $(deriveJSON defaultOptions ''NickInfo)
 
 data PushRequest = PushRequest { channelID :: Text

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -49,8 +49,12 @@ data IssueCreditLog = IssueCreditLog { ucac :: Address
                                      , amount :: Integer
                                      , nonce :: Integer
                                      , memo :: Text
-                                     } deriving (Show, Eq, Generic)
+                                     } deriving (Show, Generic)
 $(deriveJSON defaultOptions ''IssueCreditLog)
+
+instance Eq IssueCreditLog where
+    (==) (IssueCreditLog u1 c1 d1 a1 n1 _) (IssueCreditLog u2 c2 d2 a2 n2 _) =
+            u1 == u2 && c1 == c2 && d1 == d2 && a1 == a2 && n1 == n2
 
 -- `a` is a phantom type that indicates whether a record has been signed or not
 data CreditRecord = CreditRecord { creditor :: Address

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -77,7 +77,7 @@ $(deriveJSON defaultOptions ''NickRequest)
 
 data NickInfo = NickInfo { addr :: Address
                          , nick :: Text
-                         } deriving Show
+                         } deriving (Show, Generic)
 $(deriveJSON defaultOptions ''NickInfo)
 
 data PushRequest = PushRequest { channelID :: Text

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -8,6 +8,7 @@ module Lndr.Types
     , ServerConfig(..)
     , NickRequest(..)
     , NickInfo(..)
+    , PushRequest(..)
     , CreditRecord(CreditRecord, hash, creditor, debtor, submitter, signature, nonce)
     , IssueCreditLog(IssueCreditLog, ucac, amount)
     , RejectRecord(RejectRecord)
@@ -78,6 +79,12 @@ data NickInfo = NickInfo { addr :: Address
                          , nick :: Text
                          } deriving Show
 $(deriveJSON defaultOptions ''NickInfo)
+
+data PushRequest = PushRequest { channelID :: Text
+                               , platform :: Text
+                               }
+$(deriveJSON defaultOptions ''PushRequest)
+
 
 data ServerConfig = ServerConfig { lndrUcacAddr :: !Address
                                  , creditProtocolAddress :: !Address

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -27,6 +27,9 @@ module Lndr.CLI.Args (
     , checkPending
     , submitCredit
     , rejectCredit
+    , getBalance
+    , getTwoPartyBalance
+    , getCounterparties
     , getTransactions
 
     -- * notifications-related requests
@@ -168,6 +171,12 @@ getTransactions url address = do
     HTTP.getResponseBody <$> HTTP.httpJSON initReq
 
 
+getCounterparties :: String -> Address -> IO [Address]
+getCounterparties url address = do
+    initReq <- HTTP.parseRequest $ url ++ "/counterparties/" ++ show address
+    HTTP.getResponseBody <$> HTTP.httpJSON initReq
+
+
 setGasPrice :: String -> Address -> Integer -> IO Int
 setGasPrice url addr price = do
     initReq <- HTTP.parseRequest $ url ++ "/gas_price"
@@ -237,6 +246,13 @@ getFriends url userAddr = do
 getBalance :: String -> Address -> IO Integer
 getBalance url userAddr = do
     req <- HTTP.parseRequest $ url ++ "/balance/" ++ show userAddr
+    HTTP.getResponseBody <$> HTTP.httpJSON req
+
+
+getTwoPartyBalance :: String -> Address -> Address -> IO Integer
+getTwoPartyBalance url userAddr counterPartyAddr = do
+    let fullUrl = url ++ "/balance/" ++ show userAddr ++ "/" ++ show counterPartyAddr
+    req <- HTTP.parseRequest fullUrl
     HTTP.getResponseBody <$> HTTP.httpJSON req
 
 

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -273,3 +273,10 @@ rejectCredit url secretKey hash = do
                 HTTP.setRequestMethod "POST" initReq
     resp <- HTTP.httpNoBody req
     return $ HTTP.getResponseStatusCode resp
+
+
+registerChannel :: String -> Address -> PushRequest -> IO Int
+registerChannel url addr pushReq = do
+    initReq <- HTTP.parseRequest $ url ++ "/register_push/" ++ show addr
+    let req = HTTP.setRequestBodyJSON pushReq $ HTTP.setRequestMethod "POST" initReq
+    HTTP.getResponseStatusCode <$> HTTP.httpNoBody req

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -21,6 +21,7 @@ module Lndr.CLI.Args (
     -- * friend-related requests
     , addFriend
     , getFriends
+    , removeFriend
 
     -- * credit-related requests
     , checkPending

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -6,19 +6,29 @@ module Lndr.CLI.Args (
       LndrCmd(..)
     , programModes
     , runMode
+    , userFromSK
+
+    -- * nick-related requests
     , getNick
     , setNick
     , searchNick
     , takenNick
+
+    -- * gas-related requests
     , getGasPrice
     , setGasPrice
+
+    -- * friend-related requests
     , addFriend
     , getFriends
-    , userFromSK
+
+    -- * credit-related requests
     , checkPending
     , submitCredit
     , rejectCredit
     , getTransactions
+
+    -- * notifications-related requests
     , registerChannel
     ) where
 

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -19,6 +19,7 @@ module Lndr.CLI.Args (
     , submitCredit
     , rejectCredit
     , getTransactions
+    , registerChannel
     ) where
 
 import           Data.Data

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -18,8 +18,12 @@ ucacAddr = "0x7899b83071d9704af0b132859a04bb1698a3acaf"
 testUrl = "http://localhost:80"
 testPrivkey1 = "7231a774a538fce22a329729b03087de4cb4a1119494db1c10eae3bb491823e7"
 testPrivkey2 = "f581608ccd4dcd78e341e464b86f268b77ee2673acc705023e64eeb5a4e31490"
+testPrivkey3 = "b217205550c6011141e3580142ac43d7d41d217102f30e816eb36b70727e292e"
+testPrivkey4 = "024f55d169862624eec05be973a38f52ad252b3bcc0f0ed1927defa4ab4ea098"
 testAddress1 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey1
 testAddress2 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey2
+testAddress3 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey3
+testAddress4 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey4
 testSearch = "test"
 testNick1 = "test1"
 testNick2 = "test2"
@@ -51,38 +55,44 @@ nickTest = do
     nickTaken <- takenNick testUrl testNick1
     assertBool "after db reset all nicks are available" (not nickTaken)
     -- set nick for user1
-    httpCode <- setNick testUrl (NickRequest testAddress1 testNick1 "")
+    httpCode <- setNick testUrl (NickRequest testAddress3 testNick1 "")
     assertEqual "add friend success" 204 httpCode
     -- check that test nick is no longer available
     nickTaken <- takenNick testUrl testNick1
     assertBool "nicks already in db are not available" nickTaken
     -- check that nick for user1 properly set
-    queriedNick <- getNick testUrl testAddress1
+    queriedNick <- getNick testUrl testAddress3
     assertEqual "nick is set and queryable" queriedNick testNick1
     -- fail to set identical nick for user2
-    httpCode <- setNick testUrl (NickRequest testAddress2 testNick1 "")
+    httpCode <- setNick testUrl (NickRequest testAddress4 testNick1 "")
     assertBool "duplicate nick is rejected with user error" (httpCode /= 204)
     -- change user1 nick
-    httpCode <- setNick testUrl (NickRequest testAddress1 testNick2 "")
+    httpCode <- setNick testUrl (NickRequest testAddress3 testNick2 "")
     assertEqual "change nick success" 204 httpCode
     -- check that user1's nick was successfully changed
-    queriedNick <- getNick testUrl testAddress1
+    queriedNick <- getNick testUrl testAddress3
     assertEqual "nick is set and queryable" queriedNick testNick2
 
     -- set user2's nick
-    httpCode <- setNick testUrl (NickRequest testAddress2 testNick1 "")
+    httpCode <- setNick testUrl (NickRequest testAddress4 testNick1 "")
     assertEqual "previously used nickname is settable" 204 httpCode
 
     fuzzySearchResults <- searchNick testUrl testSearch
     assertEqual "search returns both results" 2 $ length fuzzySearchResults
 
     -- user1 adds user2 as a friend
-    httpCode <- addFriend testUrl testAddress1 testAddress2
+    httpCode <- addFriend testUrl testAddress3 testAddress4
     assertEqual "add friend success" 204 httpCode
     -- verify that friend has been added
-    friends <- getFriends testUrl testAddress1
-    print friends
-    assertEqual "friend properly added" [testAddress2] ((\(NickInfo addr _) -> addr) <$> friends)
+    friends <- getFriends testUrl testAddress3
+    assertEqual "friend properly added" [NickInfo testAddress4 testNick1] friends
+
+    -- user3 removes user4 from friends
+    removeFriend testUrl testAddress3 testAddress4
+
+    -- verify that friend has been removed
+    friends <- getFriends testUrl testAddress3
+    assertEqual "friend properly removed" [] friends
 
 
 basicLendTest :: Assertion

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -140,5 +140,5 @@ basicGasTest = do
 
 basicNotificationsTest :: Assertion
 basicNotificationsTest = do
-    registerChannel testUrl estAddress1 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios")
+    httpCode <- registerChannel testUrl testAddress1 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios")
     assertEqual "register channel success" 204 httpCode

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -132,7 +132,17 @@ basicLendTest = do
     assertEqual "zero pending records found for user1" 0 (length creditRecords1)
 
     verifiedRecords1 <- getTransactions testUrl testAddress1
-    assertEqual "one pending record found for user1" 1 (length verifiedRecords1)
+    assertEqual "one verified record found for user1" 1 (length verifiedRecords1)
+
+    balance <- getBalance testUrl testAddress1
+    assertEqual "user1's total balance is 100" 100 balance
+
+    twoPartyBalance <- getTwoPartyBalance testUrl testAddress1 testAddress2
+    assertEqual "user1's two-party balance is 100" 100 twoPartyBalance
+
+    -- user1's counterparties list is [user2]
+    counterparties <- getCounterparties testUrl testAddress1
+    assertEqual "user1's counterparties properly calculated" [testAddress2] counterparties
 
 
 basicGasTest :: Assertion

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -82,8 +82,7 @@ nickTest = do
     -- verify that friend has been added
     friends <- getFriends testUrl testAddress1
     print friends
-    -- threadDelay 1000000 -- delay one second
-    -- assertEqual "friend properly added" [testAddress2] ((\(NickInfo addr _) -> addr) <$> friends)
+    assertEqual "friend properly added" [testAddress2] ((\(NickInfo addr _) -> addr) <$> friends)
 
 
 basicLendTest :: Assertion
@@ -138,9 +137,8 @@ basicGasTest = do
     newPrice <- getGasPrice testUrl
     assertEqual "gas price doubled" newPrice (price * 2)
 
+
 basicNotificationsTest :: Assertion
 basicNotificationsTest = do
-    initReq <- HTTP.parseRequest $ url ++ "/register_push/" ++ show testAddress1
-    let req = HTTP.setRequestBodyJSON (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios") $ HTTP.setRequestMethod "POST" initReq
-    httpCode <- HTTP.getResponseStatusCode <$> HTTP.httpJSON req
+    registerChannel testUrl estAddress1 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios")
     assertEqual "register channel success" 204 httpCode

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -139,4 +139,8 @@ basicGasTest = do
     assertEqual "gas price doubled" newPrice (price * 2)
 
 basicNotificationsTest :: Assertion
-basicNotificationsTest = undefined
+basicNotificationsTest = do
+    initReq <- HTTP.parseRequest $ url ++ "/register_push/" ++ show testAddress1
+    let req = HTTP.setRequestBodyJSON (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios") $ HTTP.setRequestMethod "POST" initReq
+    httpCode <- HTTP.getResponseStatusCode <$> HTTP.httpJSON req
+    assertEqual "register channel success" 204 httpCode

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -39,6 +39,9 @@ tests = [ testGroup "Nicks"
         , testGroup "Admin"
             [ testCase "get and set gas price" basicGasTest
             ]
+        , testGroup "Notifications"
+            [ testCase "registerChannel" basicNotificationsTest
+            ]
         ]
 
 
@@ -134,3 +137,6 @@ basicGasTest = do
     -- check that gas price has been doubled
     newPrice <- getGasPrice testUrl
     assertEqual "gas price doubled" newPrice (price * 2)
+
+basicNotificationsTest :: Assertion
+basicNotificationsTest = undefined


### PR DESCRIPTION
- added `/register_push` endpoint for registering notifications channel
   + added `/register_push` test
- added `/remove_friends` test
- added `/counterparties`, `/balance/:user` and `/balance/:user1/:user2` tests
- fixed nick endpoint db calls
   + cleanup up db code by making `FromRow` instance for `NickInfo`
   + made separate db calls for `/taken_nick` and `/search_nick` endpoints
- added `/unsubmitted` cli functionality
   + fixed `/unsubmitted` bug related to bad `IssueCreditLog` comparisons. memos with uft8 chars were throwing things off.