### PR TITLE
normalizing db tables, automating settlement amount & blocknumber params

### DIFF
--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -6,7 +6,7 @@ CREATE TABLE pending_credits (
     debtor      CHAR(40),
     amount      BIGINT,
     memo        CHAR(32),
-    signature   CHAR(130),
+    signature   CHAR(130)
 );
 
 CREATE TABLE verified_credits (
@@ -17,7 +17,7 @@ CREATE TABLE verified_credits (
     amount             BIGINT,
     memo               CHAR(32),
     creditor_signature CHAR(130),
-    debtor_signature   CHAR(130),
+    debtor_signature   CHAR(130)
 );
 
 CREATE TABLE settlements (

--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -7,7 +7,6 @@ CREATE TABLE pending_credits (
     amount      BIGINT,
     memo        CHAR(32),
     signature   CHAR(130),
-    settlement  BOOLEAN NOT NULL
 );
 
 CREATE TABLE verified_credits (
@@ -19,7 +18,14 @@ CREATE TABLE verified_credits (
     memo               CHAR(32),
     creditor_signature CHAR(130),
     debtor_signature   CHAR(130),
-    settlement         BOOLEAN NOT NULL
+);
+
+CREATE TABLE settlements (
+    hash               CHAR(64) PRIMARY KEY,
+    amount             BIGINT NOT NULL,
+    currency           CHAR(3) NOT NULL,
+    blocknumber        BIGINT NOT NULL,
+    verified           BOOLEAN NOT NULL
 );
 
 CREATE TABLE friendships (

--- a/lndr-backend/lndr-backend.cabal
+++ b/lndr-backend/lndr-backend.cabal
@@ -40,6 +40,7 @@ library
                      , http-client
                      , http-conduit
                      , http-types
+                     , lens
                      , listsafe
                      , list-t
                      , memory

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -151,12 +151,11 @@ insertSettlementData hash (SettlementData amount currency blocknumber) conn =
 insertPending :: CreditRecord -> Maybe SettlementData -> Connection -> IO Int
 insertPending creditRecord settlementDataM conn = do
     traverse_ (flip (insertSettlementData (hash creditRecord)) conn) settlementDataM
-    fromIntegral <$> execute conn "INSERT INTO pending_credits (creditor, debtor, amount, memo, submitter, nonce, hash, signature) VALUES (?,?,?,?,?,?,?,?,?)" (creditRecordToPendingTuple creditRecord)
+    fromIntegral <$> execute conn "INSERT INTO pending_credits (creditor, debtor, amount, memo, submitter, nonce, hash, signature) VALUES (?,?,?,?,?,?,?,?)" (creditRecordToPendingTuple creditRecord)
 
 
--- TODO set block number here for eth settlment
-insertCredit :: Text -> Text -> CreditRecord -> Maybe SettlementData -> Connection -> IO Int
-insertCredit creditorSig debtorSig (CreditRecord creditor debtor amount memo _ nonce hash _ _ _ _) settlement conn =
+insertCredit :: Text -> Text -> CreditRecord -> Connection -> IO Int
+insertCredit creditorSig debtorSig (CreditRecord creditor debtor amount memo _ nonce hash _ _ _ _) conn =
     fromIntegral <$> execute conn "INSERT INTO verified_credits (creditor, debtor, amount, memo, nonce, hash, creditor_signature, debtor_signature) VALUES (?,?,?,?,?,?,?,?,?)" (creditor, debtor, amount, memo, nonce, hash, creditorSig, debtorSig)
 
 

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -127,7 +127,7 @@ lookupPending hash conn = (fmap creditRowToCreditRecord . listToMaybe) <$> query
 -- non-settlement records
 lookupPendingByAddress :: Address -> Bool -> Connection -> IO [CreditRecord]
 lookupPendingByAddress addr True conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, pending_credits.amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
-lookupPendingByAddress addr False conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, pending_credits.amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
+lookupPendingByAddress addr False conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, pending_credits.amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlements.hash IS NULL" (addr, addr)
 
 
 lookupPendingSettlementByAddresses :: Address -> Address -> Connection -> IO [Only Text]

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -174,9 +174,9 @@ allCredits conn = query conn "SELECT creditor, creditor, debtor, amount, nonce, 
 -- non-settlement records
 lookupCreditByAddress :: Address -> Bool -> Connection -> IO [IssueCreditLog]
 -- return all settlement records
-lookupCreditByAddress addr True conn = query conn "SELECT creditor, creditor, debtor, amount, nonce, memo FROM verified_credits JOIN settlements ON verified_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
+lookupCreditByAddress addr True conn = query conn "SELECT creditor, creditor, debtor, verified_credits.amount, nonce, memo FROM verified_credits JOIN settlements ON verified_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
 -- return all non-settlement records
-lookupCreditByAddress addr False conn = query conn "SELECT creditor, creditor, debtor, amount, nonce, memo FROM verified_credits LEFT JOIN settlements ON verified_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlements.hash IS NULL" (addr, addr)
+lookupCreditByAddress addr False conn = query conn "SELECT creditor, creditor, debtor, verified_credits.amount, nonce, memo FROM verified_credits LEFT JOIN settlements ON verified_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlements.hash IS NULL" (addr, addr)
 
 
 counterpartiesByAddress :: Address -> Connection -> IO [Address]

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -28,6 +28,7 @@ module Lndr.Db (
     , lookupCreditByAddress
     , counterpartiesByAddress
     , lookupCreditByHash
+    , lookupPendingSettlementByAddresses
     , verifyCreditByHash
     , userBalance
     , twoPartyBalance
@@ -124,6 +125,10 @@ lookupPending hash conn = listToMaybe <$> query conn "SELECT creditor, debtor, a
 lookupPendingByAddress :: Address -> Bool -> Connection -> IO [CreditRecord]
 lookupPendingByAddress addr True conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.has WHERE (creditor = ? OR debtor = ?)" (addr, addr)
 lookupPendingByAddress addr False conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.has WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
+
+
+lookupPendingSettlementByAddresses :: Address -> Address -> Connection -> IO [Only Text]
+lookupPendingSettlementByAddresses p1 p2 conn = query conn "SELECT hash FROM verified_credits JOIN settlements ON settlements.hash = verified_credits.hash WHERE ((creditor = ? AND debtor = ?) OR (creditor = ? AND debtor = ?)) AND settlements.verified = FALSE" (p1, p2, p2, p1)
 
 
 lookupPendingByAddresses :: Address -> Address -> Connection -> IO [CreditRecord]

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -157,7 +157,7 @@ insertPending creditRecord settlementDataM conn = do
 
 insertCredit :: Text -> Text -> CreditRecord -> Connection -> IO Int
 insertCredit creditorSig debtorSig (CreditRecord creditor debtor amount memo _ nonce hash _ _ _ _) conn =
-    fromIntegral <$> execute conn "INSERT INTO verified_credits (creditor, debtor, amount, memo, nonce, hash, creditor_signature, debtor_signature) VALUES (?,?,?,?,?,?,?,?,?)" (creditor, debtor, amount, memo, nonce, hash, creditorSig, debtorSig)
+    fromIntegral <$> execute conn "INSERT INTO verified_credits (creditor, debtor, amount, memo, nonce, hash, creditor_signature, debtor_signature) VALUES (?,?,?,?,?,?,?,?)" (creditor, debtor, amount, memo, nonce, hash, creditorSig, debtorSig)
 
 
 insertCredits :: [IssueCreditLog] -> Connection -> IO Int

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -122,7 +122,8 @@ lookupPending hash conn = listToMaybe <$> query conn "SELECT creditor, debtor, a
 
 
 lookupPendingByAddress :: Address -> Bool -> Connection -> IO [CreditRecord]
-lookupPendingByAddress addr settlement conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits WHERE (creditor = ? OR debtor = ?) AND settlement = ?" (addr, addr, settlement)
+lookupPendingByAddress addr True conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.has WHERE (creditor = ? OR debtor = ?)" (addr, addr)
+lookupPendingByAddress addr False conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.has WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
 
 
 lookupPendingByAddresses :: Address -> Address -> Connection -> IO [CreditRecord]

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -125,12 +125,12 @@ lookupPending hash conn = listToMaybe <$> query conn "SELECT creditor, debtor, a
 -- Boolean parameter determines if search is through settlement records or
 -- non-settlement records
 lookupPendingByAddress :: Address -> Bool -> Connection -> IO [CreditRecord]
-lookupPendingByAddress addr True conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
-lookupPendingByAddress addr False conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
+lookupPendingByAddress addr True conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
+lookupPendingByAddress addr False conn = query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
 
 
 lookupPendingSettlementByAddresses :: Address -> Address -> Connection -> IO [Only Text]
-lookupPendingSettlementByAddresses p1 p2 conn = query conn "SELECT hash FROM verified_credits JOIN settlements ON settlements.hash = verified_credits.hash WHERE ((creditor = ? AND debtor = ?) OR (creditor = ? AND debtor = ?)) AND settlements.verified = FALSE" (p1, p2, p2, p1)
+lookupPendingSettlementByAddresses p1 p2 conn = query conn "SELECT verified_credits.hash FROM verified_credits JOIN settlements ON settlements.hash = verified_credits.hash WHERE ((creditor = ? AND debtor = ?) OR (creditor = ? AND debtor = ?)) AND settlements.verified = FALSE" (p1, p2, p2, p1)
 
 
 lookupPendingByAddresses :: Address -> Address -> Connection -> IO [CreditRecord]
@@ -224,6 +224,7 @@ insertPushDatum addr channelID platform conn = fromIntegral <$>
 
 lookupPushDatumByAddress :: Address -> Connection -> IO (Maybe (Text, DevicePlatform))
 lookupPushDatumByAddress addr conn = listToMaybe <$> query conn "SELECT channel_id, platform FROM push_data WHERE address = ?" (Only addr)
+
 
 creditRecordToPendingTuple :: CreditRecord
                            -> (Address, Address, Integer, Text, Address, Integer, Text, Text)

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -170,6 +170,8 @@ allCredits :: Connection -> IO [IssueCreditLog]
 allCredits conn = query conn "SELECT creditor, creditor, debtor, amount, nonce, memo FROM verified_credits" ()
 
 -- TODO fix this creditor, creditor repetition
+-- Boolean parameter determines if search is through settlement records or
+-- non-settlement records
 lookupCreditByAddress :: Address -> Bool -> Connection -> IO [IssueCreditLog]
 -- return all settlement records
 lookupCreditByAddress addr True conn = query conn "SELECT creditor, creditor, debtor, amount, nonce, memo FROM verified_credits JOIN settlements ON verified_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
@@ -186,7 +188,8 @@ lookupCreditByHash :: Text -> Connection -> IO (Maybe (CreditRecord, Text, Text)
 lookupCreditByHash hash conn = (fmap process . listToMaybe) <$> query conn "SELECT creditor, debtor, amount, nonce, memo, creditor_signature, debtor_signature FROM verified_credits WHERE hash = ?" (Only hash)
     where process (creditor, debtor, amount, nonce, memo, sig1, sig2) = ( CreditRecord creditor debtor
                                                                                        amount memo
-                                                                                       creditor nonce hash sig1 Nothing Nothing Nothing
+                                                                                       creditor nonce hash sig1
+                                                                                       Nothing Nothing Nothing
                                                                         , sig1
                                                                         , sig2
                                                                         )

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -126,8 +126,8 @@ lookupPending hash conn = (fmap creditRowToCreditRecord . listToMaybe) <$> query
 -- Boolean parameter determines if search is through settlement records or
 -- non-settlement records
 lookupPendingByAddress :: Address -> Bool -> Connection -> IO [CreditRecord]
-lookupPendingByAddress addr True conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
-lookupPendingByAddress addr False conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
+lookupPendingByAddress addr True conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, pending_credits.amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?)" (addr, addr)
+lookupPendingByAddress addr False conn = fmap creditRowToCreditRecord <$> query conn "SELECT creditor, debtor, pending_credits.amount, memo, submitter, nonce, pending_credits.hash, signature FROM pending_credits LEFT JOIN settlements ON pending_credits.hash = settlements.hash WHERE (creditor = ? OR debtor = ?) AND settlement.hash IS NULL" (addr, addr)
 
 
 lookupPendingSettlementByAddresses :: Address -> Address -> Connection -> IO [Only Text]

--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -25,6 +25,13 @@ crSigned = CreditRecord "0x11edd217a875063583dd1b638d16810c5d34d54b"
                         0
                         "0x4358c649de5746c91673378dd4c40a78feda715166913e09ded45343ff76841c"
                         "0x457b0db63b83199f305ef29ba2d7678820806d98abbe3f6aafe015957ecfc5892368b4432869830456c335ade4f561603499d0216cda3af7b6b6cadf6f273c101b"
+                        Nothing
+                        Nothing
+                        Nothing
+
+instance ToSample ConfigResponse where
+    toSamples _ = singleSample $ ConfigResponse "0x11edd217a875063583dd1b638d16810c5d34d54b"
+                                                "0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb"
 
 instance ToSample CreditRecord where
     toSamples _ = singleSample crSigned

--- a/lndr-backend/src/Lndr/EthereumInterface.hs
+++ b/lndr-backend/src/Lndr/EthereumInterface.hs
@@ -116,8 +116,7 @@ settlementDataFromCreditRecord (CreditRecord _ _ amount _ _ _ _ _ saM scM sbnM) 
     Just currency -> do
         price <- queryEtheruemPrice
         -- assumes USD / ETH settlement for now
-        -- TODO make sure floor is what you want -- check uni
-        let settlementAmount = floor $ fromIntegral amount * unPrice price
+        let settlementAmount = floor $ fromIntegral amount * unPrice price * 10 ^ 18
         blockNumber <- currentBlockNumber
         return . Just $ SettlementData settlementAmount currency blockNumber
     Nothing -> return Nothing

--- a/lndr-backend/src/Lndr/EthereumInterface.hs
+++ b/lndr-backend/src/Lndr/EthereumInterface.hs
@@ -49,7 +49,7 @@ import           Prelude hiding (lookup, (!!))
 
 finalizeTransaction :: ServerConfig -> Text -> Text -> CreditRecord
                     -> IO (Either Web3Error TxHash)
-finalizeTransaction config sig1 sig2 (CreditRecord creditor debtor amount memo _ _ _ _) = do
+finalizeTransaction config sig1 sig2 (CreditRecord creditor debtor amount memo _ _ _ _ _ _ _) = do
       let (sig1r, sig1s, sig1v) = decomposeSig sig1
           (sig2r, sig2s, sig2v) = decomposeSig sig2
           encodedMemo :: BytesN 32

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -34,6 +34,7 @@ module Lndr.Handler (
     , unsubmittedHandler
     , resubmitHandler
     , registerPushHandler
+    , configHandler
     ) where
 
 import           Lndr.Handler.Admin

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -10,8 +10,6 @@ module Lndr.Handler (
     , transactionsHandler
     , pendingHandler
     , pendingSettlementsHandler
-    , lendSettleHandler
-    , borrowSettleHandler
     , lendHandler
     , borrowHandler
     , nonceHandler

--- a/lndr-backend/src/Lndr/Handler/Admin.hs
+++ b/lndr-backend/src/Lndr/Handler/Admin.hs
@@ -54,9 +54,16 @@ resubmitHandler txHash = do
         Nothing -> pure ()
     pure NoContent
 
+
 registerPushHandler :: Address -> PushRequest -> LndrHandler NoContent
 registerPushHandler addr (PushRequest channelID platform) = do
     -- TODO verify signature
     pool <- dbConnectionPool <$> ask
     liftIO . withResource pool $ Db.insertPushDatum addr channelID platform
     return NoContent
+
+
+configHandler :: LndrHandler ConfigResponse
+configHandler = do
+    configTVar <- serverConfig <$> ask
+    configToResponse <$> (liftIO . atomically $ readTVar configTVar)

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -113,7 +113,7 @@ finalizeCredit pool storedRecord config creditorSig debtorSig hash settlementM =
             -- saving transaction record
             withResource pool $ Db.insertCredit creditorSig debtorSig storedRecord settlementM
             -- delete pending record after transaction finalization
-            void . withResource pool $ Db.deletePending hash
+            void . withResource pool $ Db.deletePending hash False
 
 
 createPendingRecord :: Pool Connection -> Address -> Address -> CreditRecord -> Text -> Maybe SettlementData -> LndrHandler ()
@@ -146,7 +146,7 @@ rejectHandler(RejectRecord sig hash) = do
     case signer of
         Left _ -> throwError $ err400 { errBody = "unable to recover addr from sig" }
         Right addr -> if textToAddress addr == debtor || textToAddress addr == creditor
-                            then do liftIO . withResource pool $ Db.deletePending hash
+                            then do liftIO . withResource pool $ Db.deletePending hash True
                                     return NoContent
                             else throwError $ err400 { errBody = "bad rejection sig" }
 

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -123,6 +123,12 @@ createPendingRecord pool creditor debtor signedRecord hash settlementM = do
     unless (null existingPending) $
         throwError (err400 {errBody = "A pending credit record already exists for the two users."})
 
+    -- check if an unverified bilateral credit record exists in the
+    -- `verified_credits` table
+    existingPendingSettlement <- liftIO . withResource pool $ Db.lookupPendingSettlementByAddresses creditor debtor
+    unless (null existingPendingSettlement) $
+        throwError (err400 {errBody = "An unverified settlement credit record already exists for the two users."})
+
     -- ensuring that creditor is on debtor's friends list and vice-versa
     liftIO $ createBilateralFriendship pool creditor debtor
 

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -4,8 +4,6 @@ module Lndr.Handler.Credit (
     -- * credit submission handlers
       lendHandler
     , borrowHandler
-    , lendSettleHandler
-    , borrowSettleHandler
     , rejectHandler
     , verifyHandler
 
@@ -38,19 +36,12 @@ import           Network.Ethereum.Web3
 import           Servant
 
 
-lendSettleHandler :: CreditRecord -> LndrHandler NoContent
-lendSettleHandler creditRecord = submitHandler (creditor creditRecord) creditRecord True
-
 lendHandler :: CreditRecord -> LndrHandler NoContent
-lendHandler creditRecord = submitHandler (creditor creditRecord) creditRecord False
-
-
-borrowSettleHandler :: CreditRecord -> LndrHandler NoContent
-borrowSettleHandler creditRecord = submitHandler (debtor creditRecord) creditRecord True
+lendHandler creditRecord = submitHandler (creditor creditRecord) creditRecord
 
 
 borrowHandler :: CreditRecord -> LndrHandler NoContent
-borrowHandler creditRecord = submitHandler (debtor creditRecord) creditRecord False
+borrowHandler creditRecord = submitHandler (debtor creditRecord) creditRecord
 
 
 validSubmission :: Text -> Address -> Address -> Address -> Text -> Text -> LndrHandler ()
@@ -68,12 +59,13 @@ validSubmission memo submitterAddress creditor debtor sig hash = do
         throwError (err400 {errBody = "Bad submitter sig"})
 
 
-submitHandler :: Address -> CreditRecord -> Bool -> LndrHandler NoContent
-submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo _ _ _ sig) settlement = do
+submitHandler :: Address -> CreditRecord -> LndrHandler NoContent
+submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo _ _ _ sig _ _ _) = do
     (ServerState pool configTVar) <- ask
     config <- liftIO . atomically $ readTVar configTVar
     nonce <- liftIO . withResource pool $ Db.twoPartyNonce creditor debtor
     let hash = hashCreditRecord (lndrUcacAddr config) nonce signedRecord
+        settlementM = settlementDataFromCreditRecord signedRecord
 
     -- check that credit submission is valid
     validSubmission memo submitterAddress creditor debtor sig hash
@@ -101,31 +93,31 @@ submitHandler submitterAddress signedRecord@(CreditRecord creditor debtor _ memo
             -- update gas price to latest safelow value
             updatedConfig <- safelowUpdate config configTVar
 
-            finalizeCredit pool storedRecord updatedConfig creditorSig debtorSig hash settlement
+            finalizeCredit pool storedRecord updatedConfig creditorSig debtorSig hash settlementM
 
             -- send push notification to counterparty
             attemptToNotify "Credit Confirmation" CreditConfirmation
 
         -- if no matching transaction is found, create pending transaction
         Nothing -> do
-            createPendingRecord pool creditor debtor signedRecord hash settlement
+            createPendingRecord pool creditor debtor signedRecord hash settlementM
             -- send push notification to counterparty
             attemptToNotify "New Pending Credit" NewPendingCredit
 
     return NoContent
 
 
-finalizeCredit :: Pool Connection -> CreditRecord -> ServerConfig -> Text -> Text -> Text -> Bool -> IO ()
-finalizeCredit pool storedRecord config creditorSig debtorSig hash settlement = do
+finalizeCredit :: Pool Connection -> CreditRecord -> ServerConfig -> Text -> Text -> Text -> Maybe SettlementData -> IO ()
+finalizeCredit pool storedRecord config creditorSig debtorSig hash settlementM = do
             finalizeTransaction config creditorSig debtorSig storedRecord
             -- saving transaction record
-            withResource pool $ Db.insertCredit creditorSig debtorSig storedRecord settlement
+            withResource pool $ Db.insertCredit creditorSig debtorSig storedRecord settlementM
             -- delete pending record after transaction finalization
             void . withResource pool $ Db.deletePending hash
 
 
-createPendingRecord :: Pool Connection -> Address -> Address -> CreditRecord -> Text -> Bool -> LndrHandler ()
-createPendingRecord pool creditor debtor signedRecord hash settlement = do
+createPendingRecord :: Pool Connection -> Address -> Address -> CreditRecord -> Text -> Maybe SettlementData -> LndrHandler ()
+createPendingRecord pool creditor debtor signedRecord hash settlementM = do
     -- check if a pending transaction already exists between the two users
     existingPending <- liftIO . withResource pool $ Db.lookupPendingByAddresses creditor debtor
     unless (null existingPending) $
@@ -134,7 +126,7 @@ createPendingRecord pool creditor debtor signedRecord hash settlement = do
     -- ensuring that creditor is on debtor's friends list and vice-versa
     liftIO $ createBilateralFriendship pool creditor debtor
 
-    void . liftIO . withResource pool $ Db.insertPending (signedRecord { hash = hash }) settlement
+    void . liftIO . withResource pool $ Db.insertPending (signedRecord { hash = hash }) settlementM
 
 
 createBilateralFriendship :: Pool Connection -> Address -> Address -> IO ()
@@ -148,7 +140,7 @@ rejectHandler(RejectRecord sig hash) = do
     pool <- dbConnectionPool <$> ask
     pendingRecordM <- liftIO . withResource pool $ Db.lookupPending hash
     let hashNotFound = throwError $ err404 { errBody = "credit hash does not refer to pending record" }
-    (CreditRecord creditor debtor _ _ _ _ _ _) <- maybe hashNotFound pure pendingRecordM
+    (CreditRecord creditor debtor _ _ _ _ _ _ _ _ _) <- maybe hashNotFound pure pendingRecordM
     -- recover address from sig
     let signer = EU.ecrecover (stripHexPrefix sig) hash
     case signer of
@@ -166,7 +158,7 @@ verifyHandler creditHash (Just txHash) = do
     pool <- dbConnectionPool <$> ask
     recordM <- liftIO . withResource pool $ Db.lookupCreditByHash creditHash
     (creditor, debtor, amount) <- case recordM of
-        Just (CreditRecord creditor debtor amount _ _ _ _ _, _, _) ->
+        Just (CreditRecord creditor debtor amount _ _ _ _ _ _ _ _, _, _) ->
             pure (creditor, debtor, amount)
         Nothing -> throwError $ err400 { errBody = "Unable to find matching settlement record" }
     verified <- liftIO $ verifySettlementPayment txHash debtor creditor amount

--- a/lndr-backend/src/Lndr/NetworkStatistics.hs
+++ b/lndr-backend/src/Lndr/NetworkStatistics.hs
@@ -28,7 +28,7 @@ safelowUpdate config configTVar = do
         margin = 1.3 -- multiplier for  additional assurance that tx will make it into blockchain
 
 -- TODO add error handling
--- TODO Document units of price here
+-- Returns price in USD per 1 eth
 queryEtheruemPrice :: IO EthereumPrice
 queryEtheruemPrice = do
     req <- HTTP.parseRequest "https://api.coinbase.com/v2/exchange-rates?currency=ETH"

--- a/lndr-backend/src/Lndr/NetworkStatistics.hs
+++ b/lndr-backend/src/Lndr/NetworkStatistics.hs
@@ -6,6 +6,9 @@ import           Control.Concurrent.STM
 import           Control.Exception
 import           Control.Monad.IO.Class
 import           Lndr.Types
+import           Lndr.Util
+import           Network.Ethereum.Web3
+import qualified Network.Ethereum.Web3.Eth as Eth
 import qualified Network.HTTP.Simple as HTTP
 
 
@@ -25,7 +28,16 @@ safelowUpdate config configTVar = do
         margin = 1.3 -- multiplier for  additional assurance that tx will make it into blockchain
 
 -- TODO add error handling
+-- TODO Document units of price here
 queryEtheruemPrice :: IO EthereumPrice
 queryEtheruemPrice = do
     req <- HTTP.parseRequest "https://api.coinbase.com/v2/exchange-rates?currency=ETH"
     HTTP.getResponseBody <$> HTTP.httpJSON req
+
+
+currentBlockNumber :: IO Integer
+currentBlockNumber = do
+    blockNumberTextE <- runWeb3 Eth.blockNumber
+    return $ case blockNumberTextE of
+        Right numText -> hexToInteger numText
+        Left _        -> 0

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -45,9 +45,7 @@ type LndrAPI =
    :<|> "pending_settlements" :> Capture "user" Address :> Get '[JSON] ([CreditRecord], [IssueCreditLog])
    :<|> "verify_settlement" :> Capture "hash" Text :> QueryParam "txHash" Text :> PostNoContent '[JSON] NoContent
    :<|> "pending" :> Capture "user" Address :> Get '[JSON] [CreditRecord]
-   :<|> "lend_settle" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
    :<|> "lend" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
-   :<|> "borrow_settle" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
    :<|> "borrow" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
    :<|> "reject" :> ReqBody '[JSON] RejectRecord :> PostNoContent '[JSON] NoContent
    :<|> "nonce" :> Capture "p1" Address :> Capture "p2" Address :> Get '[JSON] Nonce
@@ -93,9 +91,7 @@ server = transactionsHandler
     :<|> pendingSettlementsHandler
     :<|> verifyHandler
     :<|> pendingHandler
-    :<|> lendSettleHandler
     :<|> lendHandler
-    :<|> borrowSettleHandler
     :<|> borrowHandler
     :<|> rejectHandler
     :<|> nonceHandler

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -72,6 +72,7 @@ type LndrAPI =
    :<|> "register_push" :> Capture "user" Address
                         :> ReqBody '[JSON] PushRequest
                         :> PostNoContent '[JSON] NoContent
+   :<|> "config" :> Get '[JSON] ConfigResponse
    :<|> "docs" :> Raw
 
 
@@ -113,6 +114,7 @@ server = transactionsHandler
     :<|> unsubmittedHandler
     :<|> resubmitHandler
     :<|> registerPushHandler
+    :<|> configHandler
     :<|> Tagged serveDocs
     where serveDocs _ respond =
             respond $ responseLBS ok200 [plain] docsBS

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -95,8 +95,11 @@ data CreditRecord = CreditRecord { creditor :: Address
                                  , nonce :: Integer
                                  , hash :: Text
                                  , signature :: Text
+                                 , settlementAmount :: Maybe Integer
+                                 , settlementCurrency :: Maybe Text
+                                 , settlementBlocknumber :: Maybe Integer
                                  } deriving (Show, Generic)
-$(deriveJSON defaultOptions ''CreditRecord)
+$(deriveJSON (defaultOptions { omitNothingFields = True }) ''CreditRecord)
 
 data RejectRecord = RejectRecord { rejectSig :: Text
                                  , hash :: Text

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -16,6 +16,7 @@ module Lndr.Types
     -- TODO clean this up, very unorganized as is
     , CreditRecord(CreditRecord, hash, creditor, debtor, submitter, signature, nonce)
     , IssueCreditLog(IssueCreditLog, ucac, amount)
+    , SettlementData(..)
     , RejectRecord(RejectRecord)
     , Nonce(..)
 
@@ -28,12 +29,15 @@ module Lndr.Types
     -- * network statistics api response types
     , EthereumPrice(..)
     , GasStationResponse(..)
+    , ConfigResponse(..)
     ) where
 
 import           Control.Concurrent.STM.TVar
+import           Control.Lens (over, _head)
 import           Data.Aeson
 import           Data.Aeson.TH
 import           Data.ByteString (ByteString)
+import           Data.Char (toLower)
 import qualified Data.Configurator.Types as Conf
 import           Data.Either.Combinators (mapLeft, fromRight)
 import           Data.Hashable
@@ -63,6 +67,11 @@ newtype Nonce = Nonce { unNonce :: Integer } deriving (Show, Generic)
 
 instance ToJSON Nonce where
     toJSON (Nonce x) = toJSON x
+
+data SettlementData = SettlementData { settlementAmount :: Integer
+                                     , settlementCurrency :: Text
+                                     , settlementBlocknumber :: Integer
+                                     }
 
 data IssueCreditLog = IssueCreditLog { ucac :: Address
                                      , creditor :: Address
@@ -156,6 +165,11 @@ data ServerConfig = ServerConfig { lndrUcacAddr :: !Address
                                  , urbanAirshipKey :: !ByteString
                                  , urbanAirshipSecret :: !ByteString
                                  }
+
+data ConfigResponse = ConfigResponse { configResponseLndrAddress :: Address
+                                     , configResponseCreditProtocolAddress :: Address
+                                     }
+$(deriveJSON (defaultOptions { fieldLabelModifier = over _head toLower . drop 14 }) ''ConfigResponse)
 
 data ServerState = ServerState { dbConnectionPool :: Pool Connection
                                , serverConfig :: TVar ServerConfig

--- a/lndr-backend/src/Lndr/Util.hs
+++ b/lndr-backend/src/Lndr/Util.hs
@@ -19,7 +19,7 @@ import qualified Network.Ethereum.Web3.Address as Addr
 import           Numeric (readHex, showHex)
 
 hashCreditRecord :: Address -> Nonce -> CreditRecord -> Text
-hashCreditRecord ucacAddr nonce (CreditRecord creditor debtor amount _ _ _ _ _) =
+hashCreditRecord ucacAddr nonce (CreditRecord creditor debtor amount _ _ _ _ _ _ _ _) =
                 let message = T.concat $
                       stripHexPrefix <$> [ Addr.toText ucacAddr
                                          , Addr.toText creditor
@@ -118,3 +118,10 @@ setUcac lndrUcac creditlog =  creditlog { ucac = lndrUcac }
 
 configToResponse :: ServerConfig -> ConfigResponse
 configToResponse config = ConfigResponse (lndrUcacAddr config) (creditProtocolAddress config)
+
+settlementDataFromCreditRecord :: CreditRecord -> Maybe SettlementData
+settlementDataFromCreditRecord (CreditRecord _ _ _ _ _ _ _ _ saM scM sbnM) = do
+    sa <- saM
+    sc <- scM
+    sbn <- sbnM
+    return $ SettlementData sa sc sbn

--- a/lndr-backend/src/Lndr/Util.hs
+++ b/lndr-backend/src/Lndr/Util.hs
@@ -115,3 +115,6 @@ alignR = snd . align
 
 setUcac :: Address -> IssueCreditLog -> IssueCreditLog
 setUcac lndrUcac creditlog =  creditlog { ucac = lndrUcac }
+
+configToResponse :: ServerConfig -> ConfigResponse
+configToResponse config = ConfigResponse (lndrUcacAddr config) (creditProtocolAddress config)

--- a/lndr-backend/src/Lndr/Util.hs
+++ b/lndr-backend/src/Lndr/Util.hs
@@ -119,3 +119,7 @@ setUcac lndrUcac creditlog =  creditlog { ucac = lndrUcac }
 
 configToResponse :: ServerConfig -> ConfigResponse
 configToResponse config = ConfigResponse (lndrUcacAddr config) (creditProtocolAddress config)
+
+
+creditRowToCreditRecord :: (Address, Address, Integer, Text, Address, Integer, Text, Text) -> CreditRecord
+creditRowToCreditRecord (creditor, debtor, amount, memo, submitter, nonce, hash, signature) = CreditRecord creditor debtor amount memo submitter nonce hash signature Nothing Nothing Nothing

--- a/lndr-backend/src/Lndr/Util.hs
+++ b/lndr-backend/src/Lndr/Util.hs
@@ -116,12 +116,6 @@ alignR = snd . align
 setUcac :: Address -> IssueCreditLog -> IssueCreditLog
 setUcac lndrUcac creditlog =  creditlog { ucac = lndrUcac }
 
+
 configToResponse :: ServerConfig -> ConfigResponse
 configToResponse config = ConfigResponse (lndrUcacAddr config) (creditProtocolAddress config)
-
-settlementDataFromCreditRecord :: CreditRecord -> Maybe SettlementData
-settlementDataFromCreditRecord (CreditRecord _ _ _ _ _ _ _ _ saM scM sbnM) = do
-    sa <- saM
-    sc <- scM
-    sbn <- sbnM
-    return $ SettlementData sa sc sbn

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -118,11 +118,11 @@ runMode (Config url sk _) RejectPending = do
     print httpCode
 
 runMode (Config url sk ucacAddr) (Lend friend amount memo) = do
-    httpCode <- submitCredit (LT.unpack url) (textToAddress $ LT.toStrict ucacAddr) (LT.toStrict sk) (CreditRecord (textToAddress $ userFromSK sk) (textToAddress friend) amount memo (textToAddress $ userFromSK sk) 0 "" "" Nothing Nothing Nothing) False
+    httpCode <- submitCredit (LT.unpack url) (textToAddress $ LT.toStrict ucacAddr) (LT.toStrict sk) (CreditRecord (textToAddress $ userFromSK sk) (textToAddress friend) amount memo (textToAddress $ userFromSK sk) 0 "" "" Nothing Nothing Nothing)
     print httpCode
 
 runMode (Config url sk ucacAddr) (Borrow friend amount memo) = do
-    httpCode <- submitCredit (LT.unpack url) (textToAddress $ LT.toStrict ucacAddr) (LT.toStrict sk) (CreditRecord (textToAddress friend) (textToAddress $ userFromSK sk) amount memo (textToAddress $ userFromSK sk) 0 "" "" Nothing Nothing Nothing) False
+    httpCode <- submitCredit (LT.unpack url) (textToAddress $ LT.toStrict ucacAddr) (LT.toStrict sk) (CreditRecord (textToAddress friend) (textToAddress $ userFromSK sk) amount memo (textToAddress $ userFromSK sk) 0 "" "" Nothing Nothing Nothing)
 
     print httpCode
 
@@ -296,12 +296,12 @@ checkPending url userAddress = do
 
 
 -- TODO Don't take a credit record
-submitCredit :: String -> Address -> Text -> CreditRecord -> Bool -> IO Int
-submitCredit url ucacAddr secretKey unsignedCredit@(CreditRecord creditor debtor _ _ _ _ _ _ _ _ _) settlement = do
+submitCredit :: String -> Address -> Text -> CreditRecord -> IO Int
+submitCredit url ucacAddr secretKey unsignedCredit@(CreditRecord creditor debtor _ _ _ _ _ _ _ _ _) = do
     nonce <- getNonce url debtor creditor
     initReq <- if textToAddress (userFromSK (LT.fromStrict secretKey)) == creditor
-                   then HTTP.parseRequest $ url ++ (if settlement then "/lend_settlement" else "/lend")
-                   else HTTP.parseRequest $ url ++ (if settlement then "/borrow_settlement" else "/borrow")
+                   then HTTP.parseRequest $ url ++ "/lend"
+                   else HTTP.parseRequest $ url ++ "/borrow"
     let signedCredit = signCredit secretKey ucacAddr (unsignedCredit { nonce = nonce })
     let req = HTTP.setRequestBodyJSON signedCredit $
                 HTTP.setRequestMethod "POST" initReq

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -107,8 +107,9 @@ nickTest = do
 
 basicLendTest :: Assertion
 basicLendTest = do
-    let testCredit = CreditRecord testAddress1 testAddress2 100 "dinner" testAddress1 0 "" ""
-        badTestCredit = CreditRecord testAddress1 testAddress1 100 "dinner" testAddress1 0 "" ""
+    let testCredit = CreditRecord testAddress1 testAddress2 100 "dinner" testAddress1 0 "" "" Nothing Nothing Nothing
+        badTestCredit = CreditRecord testAddress1 testAddress1 100 "dinner" testAddress1 0 "" "" Nothing Nothing Nothing
+
         creditHash = hashCreditRecord ucacAddr (Nonce 0) testCredit
 
     -- user1 fails to submit pending credit to himself
@@ -166,7 +167,7 @@ basicSettlementTest = do
     price <- queryEtheruemPrice
     assertBool "nonzero eth price retrieved from coinbase" (unPrice price > 0)
 
-    let testCredit = CreditRecord testAddress5 testAddress6 100 "settlement" testAddress5 0 "" ""
+    let testCredit = CreditRecord testAddress5 testAddress6 100 "settlement" testAddress5 0 "" "" Nothing Nothing Nothing
         creditHash = hashCreditRecord ucacAddr (Nonce 0) testCredit
 
     -- user5 submits pending settlement credit to user6

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -113,11 +113,11 @@ basicLendTest = do
         creditHash = hashCreditRecord ucacAddr (Nonce 0) testCredit
 
     -- user1 fails to submit pending credit to himself
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 badTestCredit False
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 badTestCredit
     assertEqual "user1 cannot lend to himself" 400 httpCode
 
     -- user1 submits pending credit to user2
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 testCredit False
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 testCredit
     assertEqual "lend success" 204 httpCode
 
     -- user1 checks pending transactions
@@ -137,11 +137,11 @@ basicLendTest = do
     assertEqual "zero pending records found for user2" 0 (length creditRecords2)
 
     -- user1 attempts same credit again
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 testCredit False
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey1 testCredit
     assertEqual "lend success" 204 httpCode
 
     -- user2 accepts user1's pending credit
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey2 (testCredit { submitter = testAddress2 }) False
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey2 (testCredit { submitter = testAddress2 })
     assertEqual "borrow success" 204 httpCode
 
     -- user1's checks that he has pending credits and one verified credit
@@ -171,14 +171,13 @@ basicSettlementTest = do
         creditHash = hashCreditRecord ucacAddr (Nonce 0) testCredit
 
     -- user5 submits pending settlement credit to user6
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey5 testCredit True
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey5 testCredit
     -- assertEqual "lend (settle) success" 204 httpCode
     print httpCode
 
     -- user6 accepts user5's pending settlement credit
-    httpCode <- submitCredit testUrl ucacAddr testPrivkey6 (testCredit { submitter = testAddress6 }) True
-    -- assertEqual "borrow (settle) success" 204 httpCode
-    print httpCode
+    httpCode <- submitCredit testUrl ucacAddr testPrivkey6 (testCredit { submitter = testAddress6 })
+    assertEqual "borrow (settle) success" 204 httpCode
 
     -- user5 transfers eth to user6
     txHashE <- runWeb3 $ Eth.sendTransaction $ Call (Just testAddress5)


### PR DESCRIPTION
- simplifying credits API
  + eliminated /lend_settle, now special case of /lend
  + eliminated /lend_borrow, now special case of /borrow
- wrote function to query current block number
- normalized db by creating separate settlements table
- fixing settlement blocknumber and eth amount upon pending credit creation