### PR TITLE
/tx_hash 500 error, wei conversion issues

### DIFF
--- a/lndr-backend/src/Lndr/Db/VerifiedCredits.hs
+++ b/lndr-backend/src/Lndr/Db/VerifiedCredits.hs
@@ -46,7 +46,7 @@ settlementCreditsToVerify conn = fmap fromOnly <$> query_ conn "SELECT hash FROM
 
 
 txHashByCreditHash :: Text -> Connection -> IO (Maybe Text)
-txHashByCreditHash creditHash conn = fmap fromOnly . listToMaybe <$> query conn "SELECT tx_hash FROM settlements WHERE hash = ?" (Only creditHash)
+txHashByCreditHash creditHash conn = fmap fromOnly . join . listToMaybe <$> query conn "SELECT tx_hash FROM settlements WHERE hash = ?" (Only creditHash)
 
 
 updateSettlementTxHash :: Text -> Text -> Connection -> IO Int

--- a/lndr-backend/src/Lndr/EthereumInterface.hs
+++ b/lndr-backend/src/Lndr/EthereumInterface.hs
@@ -140,6 +140,6 @@ settlementDataFromCreditRecord (CreditRecord _ _ amount _ _ _ _ _ saM scM sbnM) 
     currency <- MaybeT (return scM :: IO (Maybe Text))
     price <- queryEtheruemPrice
     -- assumes USD / ETH settlement for now
-    let settlementAmount = floor $ fromIntegral amount * unPrice price * 10 ^ 18
+    let settlementAmount = floor $ fromIntegral amount / unPrice price * 10 ^ 18
     blockNumber <- currentBlockNumber
     return $ SettlementData settlementAmount currency blockNumber

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -221,7 +221,7 @@ txHashHandler creditHash = do
     txHashM <- liftIO . withResource pool $ Db.txHashByCreditHash creditHash
     case txHashM of
         (Just txHash) -> return txHash
-        Nothing -> throwError $ err400 { errBody = "Settlement credit not found" }
+        Nothing -> throwError $ err404 { errBody = "Settlement credit not found" }
 
 
 nonceHandler :: Address -> Address -> LndrHandler Nonce

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -33,6 +33,7 @@ module Lndr.CLI.Args (
     , getTransactions
     , getSettlements
     , getTxHash
+    , getTxHashFail
     , verifySettlement
 
     -- * notifications-related requests
@@ -287,6 +288,13 @@ getTxHash :: String -> Text -> IO Text
 getTxHash url creditHash = do
     req <- HTTP.parseRequest $ url ++ "/tx_hash/" ++ T.unpack creditHash
     HTTP.getResponseBody <$> HTTP.httpJSON req
+
+
+-- TODO how should I handle HTTP errors nicely in these tests?
+getTxHashFail :: String -> Text -> IO Int
+getTxHashFail url creditHash = do
+    req <- HTTP.parseRequest $ url ++ "/tx_hash/" ++ T.unpack creditHash
+    HTTP.getResponseStatusCode <$> HTTP.httpNoBody req
 
 
 signCredit :: Text -> Address -> CreditRecord -> CreditRecord

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -230,6 +230,9 @@ basicSettlementTest = do
     -- httpCode <- verifySettlement testUrl creditHash incorrectTxHash testPrivkey5
     -- assertEqual "verification failure upon bad txHash submission" 400 httpCode
 
+    httpCode <- getTxHashFail testUrl creditHash
+    assertEqual "404 upon hash not found error" 404 httpCode
+
     -- user5 verifies that he has made the settlement credit
     httpCode <- verifySettlement testUrl creditHash txHash testPrivkey5
     assertEqual "verification success" 204 httpCode


### PR DESCRIPTION
addressing bugs will found this morning.

- when a tx_hash does not exist for a certain settlement record, the server was returning 500 due to a sql error. Now it returns 400.

- fixing faulty settlement amount calculation