### PR TITLE
✅ Add CircleCI project configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,15 +24,15 @@ jobs:
         keys:
         - v2-{{ checksum "stack.yaml" }}
     - run:
-        name: Setup
+        name: stack setup
         command: |
           stack setup
     - run:
-        name: Build
+        name: stack build
         command: |
           stack build
     - run:
-        name: Install
+        name: stack install
         command: |
           stack install
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,6 @@ jobs:
         command: |
           stack setup
     - run:
-        name: stack build
-        command: |
-          stack build
-    - run:
         name: stack install
         command: |
           stack install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           curl -sSL https://get.haskellstack.org/ | sh
     - restore_cache:
         keys:
-        - v1-{{ checksum "stack.yaml" }}
+        - v2-{{ checksum "stack.yaml" }}
     - run:
         name: Setup
         command: |
@@ -36,7 +36,7 @@ jobs:
         command: |
           stack install
     - save_cache:
-        key: v1-{{ checksum "stack.yaml" }}
+        key: v2-{{ checksum "stack.yaml" }}
         paths:
         - ~/.ghc
         - ~/.cabal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,9 @@ jobs:
     - save_cache:
         key: v1-{{ checksum "stack.yaml" }}
         paths:
-        - "${HOME}/.ghc"
-        - "${HOME}/.cabal"
-        - "${HOME}/.stack"
+        - ~/.ghc
+        - ~/.cabal
+        - ~/.stack
     - run:
         name: Prepare artifacts
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ jobs:
         name: Install the Haskell tool stack
         command: |
           curl -sSL https://get.haskellstack.org/ | sh
+    - restore_cache:
+        keys:
+        - v1-{{ checksum "stack.yaml" }}
     - run:
         name: Setup
         command: |
@@ -32,6 +35,12 @@ jobs:
         name: Install
         command: |
           stack install
+    - save_cache:
+        key: v1-{{ checksum "stack.yaml" }}
+        paths:
+        - "${HOME}/.ghc"
+        - "${HOME}/.cabal"
+        - "${HOME}/.stack"
     - run:
         name: Prepare artifacts
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+defaults: &defaults
+  working_directory: ~
+  docker:
+  - image: debian:stretch
+
+version: 2
+jobs:
+  build:
+    <<: *defaults
+    steps:
+    - run:
+        name: Install system dependencies
+        command: |
+          apt-get update
+          apt-get install build-essential curl dh-autoreconf git libpq-dev postgresql postgresql-client -y
+          apt-get --purge autoremove
+          apt-get clean
+    - checkout
+    - run:
+        name: Install the Haskell tool stack
+        command: |
+          curl -sSL https://get.haskellstack.org/ | sh
+    - run:
+        name: Setup
+        command: |
+          stack setup
+    - run:
+        name: Build
+        command: |
+          stack build
+    - run:
+        name: Install
+        command: |
+          stack install
+    - run:
+        name: Prepare artifacts
+        command: |
+          mkdir artifacts
+          for artifact in lndr lndr-server; do
+            cp "${HOME}/.local/bin/${artifact}" artifacts/
+          done
+    - store_artifacts:
+        path: artifacts


### PR DESCRIPTION
Pipeline for generating `lndr-server` binary, for consumption downstream by the base AMI builder [here](https://github.com/blockmason/lndr-service.ami).