### PR TITLE
📝 Add CircleCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Server, CLI, and UCAC Solidity contracts.
 
 
-[![Travis CI](https://img.shields.io/travis/blockmason/lndr.svg)](https://travis-ci.org/blockmason/lndr)
-[![CircleCI](https://img.shields.io/circleci/project/github/blockmason/lndr.svg)](https://circleci.com/gh/blockmason/lndr)
+[![Travis CI](https://img.shields.io/travis/blockmason/lndr.svg?label=Travis%20CI)](https://travis-ci.org/blockmason/lndr)
+[![CircleCI](https://img.shields.io/circleci/project/github/blockmason/lndr.svg?label=CircleCI)](https://circleci.com/gh/blockmason/lndr)
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 Server, CLI, and UCAC Solidity contracts.
 
-[![Travis CI](https://travis-ci.org/blockmason/lndr.svg?branch=master)](https://travis-ci.org/blockmason/lndr)
-[![CircleCI](https://circleci.com/gh/blockmason/lndr.svg?style=svg)](https://circleci.com/gh/blockmason/lndr)
+
+[![Travis CI](https://img.shields.io/travis/blockmason/lndr.svg)](https://travis-ci.org/blockmason/lndr)
+[![CircleCI](https://img.shields.io/circleci/project/github/blockmason/lndr.svg)](https://circleci.com/gh/blockmason/lndr)
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Server, CLI, and UCAC Solidity contracts.
 
-[![Build
-Status](https://travis-ci.org/blockmason/lndr.svg?branch=master)](https://travis-ci.org/blockmason/lndr)
+[![Travis CI](https://travis-ci.org/blockmason/lndr.svg?branch=master)](https://travis-ci.org/blockmason/lndr)
+[![CircleCI](https://circleci.com/gh/blockmason/lndr.svg?style=svg)](https://circleci.com/gh/blockmason/lndr)
 
 ## API
 


### PR DESCRIPTION
Looks a little funky to have multiple status badges, but it's nice to have visibility into how both builds are doing.

Using [shields.io](https://shields.io/) for these, so we get some aesthetic consistency.