### PR TITLE
🔧 Publish a more comprehensive set of build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,11 @@ jobs:
             Dockerfile \
             .dockerignore \
             artifacts/
-          for file in $(perl -n -e'/^!\/(.+)/ && print "$1\n"' < .dockerignore | xargs); do \
-            mkdir -p "artifacts/$(dirname "${file}")"
-            cp "${file}" "artifacts/${file}"
+          for file in $(perl -n -e'/^!\/(.+)/ && print "$1\n"' < .dockerignore | xargs); do
+            if [ -f "${file}" ]; then
+              mkdir -p "artifacts/$(dirname "${file}")"
+              cp "${file}" "artifacts/${file}"
+            fi
           done
 
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,11 @@ jobs:
             "${HOME}/.local/bin/lndr-server" \
             Dockerfile \
             .dockerignore \
-            $(perl -n -e'/^!\/(.+)/ && print "$1\n"' < .dockerignore | xargs) \
             artifacts/
+          for file in $(perl -n -e'/^!\/(.+)/ && print "$1\n"' < .dockerignore | xargs); do \
+            mkdir -p "artifacts/$(dirname "${file}")"
+            cp "${file}" "artifacts/${file}"
+          done
+
     - store_artifacts:
         path: artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,11 @@ jobs:
         name: Prepare artifacts
         command: |
           mkdir artifacts
-          for artifact in lndr lndr-server; do
-            cp "${HOME}/.local/bin/${artifact}" artifacts/
-          done
+          cp \
+            "${HOME}/.local/bin/lndr-server" \
+            Dockerfile \
+            .dockerignore \
+            $(perl -n -e'/^!\/(.+)/ && print "$1\n"' < .dockerignore | xargs) \
+            artifacts/
     - store_artifacts:
         path: artifacts

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@
 
 # Required by the entry point to configure the container
 !/lndr-backend/data/lndr-server.config.j2
+
+# May be provided to prevent live download of binary from CircleCI
+!/lndr-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,24 @@ RUN set -e;\
 ENV \
   LNDR_HOME=/lndr
 
-RUN set -e;\
-  curl \
-    -sSL \
-    -o /usr/bin/lndr-server \
-    $(curl \
-        -sSL \
-        'https://circleci.com/api/v1.1/project/github/blockmason/lndr/latest/artifacts?branch=master&filter=successful' \
-      | awk '/url.+lndr-server/ { print $3; }' \
-      | xargs \
-    );\
-  chmod 0555 /usr/bin/lndr-server;
-
 COPY . "${LNDR_HOME}"
 
 WORKDIR "${LNDR_HOME}"
+
+RUN set -e;\
+  [ -f "${LNDR_HOME}/lndr-server" ] && cp "${LNDR_HOME}/lndr-server" /usr/bin/lndr-server;\
+  [ -f "/usr/bin/lndr-server" ] \
+  || curl \
+      -sSL \
+      -o /usr/bin/lndr-server \
+      $(\
+        curl \
+          -sSL \
+          'https://circleci.com/api/v1.1/project/github/blockmason/lndr/latest/artifacts?branch=master&filter=successful' \
+        | awk '/url.+lndr-server/ { print $3; }' \
+        | xargs \
+      );\
+  chmod 0555 /usr/bin/lndr-server;
 
 ENV \
   AWS_ACCESS_KEY_ID="" \


### PR DESCRIPTION
Even though the Dockerfile (and its supporting files) are not technically artifacts resulting from a build, these files are necessary in order for downstream deployment tooling to deploy the service. While these files are also available from the repository in GitHub, having all required artifacts to
continue deployment available in one place is worth having a little duplication, and decoupling the downstream services from having a direct dependency on the source code in GitHub is a nice benefit.