### PR TITLE
adding currency-specific urban airship creds

### DIFF
--- a/lndr-backend/data/lndr-server.config.j2
+++ b/lndr-backend/data/lndr-server.config.j2
@@ -26,6 +26,21 @@ urban-airship {
   key = "{{URBAN_AIRSHIP_KEY}}"
   secret = "{{URBAN_AIRSHIP_SECRET}}"
 }
+urban-airship {
+    usd {
+        key = "{{URBAN_AIRSHIP_KEY_USD}}"
+        secret = "{{URBAN_AIRSHIP_SECRET_USD}}"
+    }
+    jpy {
+        key = "{{URBAN_AIRSHIP_KEY_JPY}}"
+        secret = "{{URBAN_AIRSHIP_SECRET_JPY}}"
+    }
+    krw {
+        key = "{{URBAN_AIRSHIP_KEY_KRW}}"
+        secret = "{{URBAN_AIRSHIP_SECRET_KRW}}"
+    }
+}
+
 
 heartbeat-interval = {{HEARTBEAT_INTERVAL}}
 

--- a/lndr-backend/data/lndr-server.config.test
+++ b/lndr-backend/data/lndr-server.config.test
@@ -33,8 +33,18 @@ max-gas = 250000
 
 # urban airship credentials used for push notifications
 urban-airship {
-    key = "4_88888888888mmmmmmmmm"
-    secret = "rrrrrrrrrrrrrrrrrrrrrr"
+    usd {
+        key = "4_88888888888mmmmmmmmm"
+        secret = "rrrrrrrrrrrrrrrrrrrrrr"
+    }
+    jpy {
+        key = "4_88888888888mmmmmmmmm"
+        secret = "rrrrrrrrrrrrrrrrrrrrrr"
+    }
+    krw {
+        key = "4_88888888888mmmmmmmmm"
+        secret = "rrrrrrrrrrrrrrrrrrrrrr"
+    }
 }
 
 # how often to run the heartbeat function in seconds. The heartbeat is

--- a/lndr-backend/lndr-backend.cabal
+++ b/lndr-backend/lndr-backend.cabal
@@ -40,6 +40,7 @@ library
                      , amazonka-s3
                      , base16-bytestring
                      , base64-bytestring
+                     , bimap
                      , bytestring
                      , configurator
                      , containers

--- a/lndr-backend/src/Lndr/Config.hs
+++ b/lndr-backend/src/Lndr/Config.hs
@@ -2,6 +2,7 @@
 
 module Lndr.Config where
 
+import qualified Data.Bimap              as B
 import           Data.Configurator
 import           Data.Configurator.Types
 import           Data.Default
@@ -17,7 +18,7 @@ loadConfig :: IO ServerConfig
 loadConfig = do
     config <- getMap =<< load [Required $ "lndr-backend" </> "data" </> "lndr-server.config"]
     let loadEntry x = fromMaybe (error $ T.unpack x) $ convert =<< H.lookup x config
-    return $ ServerConfig (M.fromList [ ("USD", loadEntry "lndr-ucacs.usd")
+    return $ ServerConfig (B.fromList [ ("USD", loadEntry "lndr-ucacs.usd")
                                       , ("JPY", loadEntry "lndr-ucacs.jpy")
                                       , ("KRW", loadEntry "lndr-ucacs.krw") ])
                           (loadEntry "credit-protocol-address")
@@ -33,8 +34,13 @@ loadConfig = do
                           def
                           (loadEntry "max-gas")
                           0
-                          (loadEntry "urban-airship.key")
-                          (loadEntry "urban-airship.secret")
+                          (M.fromList [ ("USD", ( loadEntry "urban-airship.usd.key"
+                                                , loadEntry "urban-airship.usd.secret"))
+                                      , ("JPY", ( loadEntry "urban-airship.jpy.key"
+                                                , loadEntry "urban-airship.jpy.secret"))
+                                      , ("KRW", ( loadEntry "urban-airship.krw.key"
+                                                , loadEntry "urban-airship.krw.secret"))
+                                      ])
                           (loadEntry "heartbeat-interval")
                           (loadEntry "aws.photo-bucket")
                           (loadEntry "aws.access-key-id")

--- a/lndr-backend/src/Lndr/Notifications.hs
+++ b/lndr-backend/src/Lndr/Notifications.hs
@@ -2,6 +2,8 @@
 
 module Lndr.Notifications where
 
+import qualified Data.Map            as M
+import           Data.Text           (Text)
 import           Lndr.Types
 import qualified Network.HTTP.Client as HTTP (applyBasicAuth)
 import qualified Network.HTTP.Simple as HTTP
@@ -10,11 +12,12 @@ import qualified Network.HTTP.Types  as HTTP (hAccept)
 
 -- | Sends a request to the Urban Airship api to send push notifications to
 -- specific mobile devices.
-sendNotification :: ServerConfig -> Notification -> IO Int
-sendNotification config notification = do
+sendNotification :: ServerConfig -> Text -> Notification -> IO Int
+sendNotification config currency notification = do
+    let Just (urbanAirshipKey, urbanAirshipSecret) = M.lookup currency $ urbanAirshipCreditialMap config
     initReq <- HTTP.parseRequest urbanAirshipUrl
     let req = HTTP.addRequestHeader HTTP.hAccept acceptContent $
-                    HTTP.applyBasicAuth (urbanAirshipKey config) (urbanAirshipSecret config) $
+                    HTTP.applyBasicAuth urbanAirshipKey urbanAirshipSecret $
                     HTTP.setRequestBodyJSON notification $ HTTP.setRequestMethod "POST" initReq
     HTTP.getResponseStatusCode <$> HTTP.httpNoBody req
     where acceptContent = "application/vnd.urbanairship+json; version=3;"

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -45,6 +45,7 @@ import           Control.Concurrent.STM.TVar
 import           Control.Lens                  (over, _head, makeLenses)
 import           Data.Aeson
 import           Data.Aeson.TH
+import qualified Data.Bimap                    as B
 import           Data.ByteString               (ByteString)
 import           Data.Char                     (toLower)
 import qualified Data.Configurator.Types       as Conf
@@ -228,27 +229,26 @@ instance FromJSON EthereumPrices where
             krw <- read <$> ratesObject .: "KRW"
             return $ EthereumPrices usd jpy krw
 
-data ServerConfig = ServerConfig { lndrUcacAddrs         :: M.Map Text Address
-                                 , creditProtocolAddress :: !Address
-                                 , issueCreditEvent      :: !Text
-                                 , scanStartBlock        :: !Integer
-                                 , dbUser                :: !Text
-                                 , dbUserPassword        :: !Text
-                                 , dbName                :: !Text
-                                 , dbHost                :: !String
-                                 , dbPort                :: !Word16
-                                 , executionAddress      :: !Address
-                                 , gasPrice              :: !Integer
-                                 , ethereumPrices        :: !EthereumPrices
-                                 , maxGas                :: !Integer
-                                 , latestBlockNumber     :: !Integer
-                                 , urbanAirshipKey       :: !ByteString
-                                 , urbanAirshipSecret    :: !ByteString
-                                 , heartbeatInterval     :: !Int
-                                 , awsPhotoBucket        :: !Text
-                                 , awsAccessKeyId        :: !ByteString
-                                 , awsSecretAccessKey    :: !ByteString
-                                 , web3Url               :: !String
+data ServerConfig = ServerConfig { lndrUcacAddrs            :: B.Bimap Text Address
+                                 , creditProtocolAddress    :: !Address
+                                 , issueCreditEvent         :: !Text
+                                 , scanStartBlock           :: !Integer
+                                 , dbUser                   :: !Text
+                                 , dbUserPassword           :: !Text
+                                 , dbName                   :: !Text
+                                 , dbHost                   :: !String
+                                 , dbPort                   :: !Word16
+                                 , executionAddress         :: !Address
+                                 , gasPrice                 :: !Integer
+                                 , ethereumPrices           :: !EthereumPrices
+                                 , maxGas                   :: !Integer
+                                 , latestBlockNumber        :: !Integer
+                                 , urbanAirshipCreditialMap :: M.Map Text (ByteString, ByteString)
+                                 , heartbeatInterval        :: !Int
+                                 , awsPhotoBucket           :: !Text
+                                 , awsAccessKeyId           :: !ByteString
+                                 , awsSecretAccessKey       :: !ByteString
+                                 , web3Url                  :: !String
                                  }
 
 -- 'ConfigResponse' contains all the server data that users have access to via

--- a/lndr-backend/src/Lndr/Util.hs
+++ b/lndr-backend/src/Lndr/Util.hs
@@ -5,6 +5,7 @@ module Lndr.Util where
 
 import           Control.Exception
 import           Control.Lens
+import qualified Data.Bimap                    as B
 import qualified Data.ByteArray                as BA
 import qualified Data.ByteString               as B
 import qualified Data.ByteString.Base16        as BS16
@@ -114,14 +115,15 @@ alignR :: Text -> Text
 alignR = snd . align
 
 
-getUcac :: M.Map Text Address -> Maybe Text -> Address
+getUcac :: B.Bimap Text Address -> Maybe Text -> Address
 getUcac ucacAddresses currency =
-    let defaultUcac = fromMaybe (error "no USD ucac registered") $ M.lookup "USD" ucacAddresses
-    in fromMaybe defaultUcac $ (`M.lookup` ucacAddresses) =<< currency
+    let defaultUcac = fromMaybe (error "no USD ucac registered") $ B.lookup "USD" ucacAddresses
+    in fromMaybe defaultUcac $ (`B.lookup` ucacAddresses) =<< currency
 
 
 configToResponse :: ServerConfig -> ConfigResponse
-configToResponse config = ConfigResponse (lndrUcacAddrs config) (creditProtocolAddress config)
+configToResponse config = ConfigResponse (B.toMap $ lndrUcacAddrs config)
+                                         (creditProtocolAddress config)
                                          (gasPrice config) (ethereumPrices config)
                                          (latestBlockNumber config - 40600)
 


### PR DESCRIPTION
- changing currency-ucac map to bimap
- creating `ubranAirshipCredentialMap` to store creds for USD, JPY and KRW apps
- updating config file format to accomodate multipe UrbanAirship credentials