### PR TITLE
🔧 Add the `lndr` CLI back in to the build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
           mkdir artifacts
           cp \
             "${HOME}/.local/bin/lndr-server" \
+            "${HOME}/.local/bin/lndr" \
             Dockerfile \
             .dockerignore \
             artifacts/


### PR DESCRIPTION
We omitted the `lndr` CLI because it previous was only used for testing purposes, but now that some administrative tasks are being added to it, we'd like to keep it around.