### PR TITLE
🚀 Add endpoint to list friend requests

### DIFF
--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -12,7 +12,7 @@ module Lndr.Db (
     , addFriends
     , removeFriends
     , lookupFriends
-    , lookupFriendsWithNick
+    , lookupFriendRequests
 
     -- * 'pending_credit' table functions
     , lookupPending

--- a/lndr-backend/src/Lndr/Db/Friendships.hs
+++ b/lndr-backend/src/Lndr/Db/Friendships.hs
@@ -19,9 +19,9 @@ removeFriends addr addresses conn = fromIntegral <$>
 
 lookupFriends :: Address -> Connection -> IO [UserInfo]
 lookupFriends addr conn =
-    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo]
+    query conn "SELECT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo]
 
 
 lookupFriendRequests :: Address -> Connection -> IO [UserInfo]
 lookupFriendRequests addr conn =
-    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo]
+    query conn "SELECT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo]

--- a/lndr-backend/src/Lndr/Db/Friendships.hs
+++ b/lndr-backend/src/Lndr/Db/Friendships.hs
@@ -14,7 +14,7 @@ addFriends addressPairs conn = fromIntegral <$>
 
 removeFriends :: Address -> [Address] -> Connection -> IO Int
 removeFriends addr addresses conn = fromIntegral <$>
-    execute conn "DELETE FROM friendships WHERE origin = ? AND friend in ?" (addr, In addresses)
+    execute conn "DELETE FROM friendships WHERE origin = ? AND friend in ? OR friend = ? AND origin in ?" (addr, In addresses, addr, In addresses)
 
 
 lookupFriends :: Address -> Connection -> IO [UserInfo]

--- a/lndr-backend/src/Lndr/Db/Friendships.hs
+++ b/lndr-backend/src/Lndr/Db/Friendships.hs
@@ -19,9 +19,9 @@ removeFriends addr addresses conn = fromIntegral <$>
 
 lookupFriends :: Address -> Connection -> IO [UserInfo]
 lookupFriends addr conn =
-    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo]
+    (query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo])
 
 
 lookupFriendRequests :: Address -> Connection -> IO [UserInfo]
 lookupFriendRequests addr conn = fmap fromOnly <$>
-    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo]
+    (query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo])

--- a/lndr-backend/src/Lndr/Db/Friendships.hs
+++ b/lndr-backend/src/Lndr/Db/Friendships.hs
@@ -19,9 +19,9 @@ removeFriends addr addresses conn = fromIntegral <$>
 
 lookupFriends :: Address -> Connection -> IO [UserInfo]
 lookupFriends addr conn =
-    (query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo])
+    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound INNER JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ?" (Only addr) :: IO [UserInfo]
 
 
 lookupFriendRequests :: Address -> Connection -> IO [UserInfo]
-lookupFriendRequests addr conn = fmap fromOnly <$>
-    (query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo])
+lookupFriendRequests addr conn =
+    query conn "SELECT DISTINCT inbound.origin, nicknames.nickname FROM friendships inbound LEFT JOIN friendships outbound ON inbound.friend = outbound.origin AND inbound.origin = outbound.friend LEFT JOIN nicknames ON nicknames.address = inbound.origin WHERE inbound.friend = ? AND outbound.friend IS NULL" (Only addr) :: IO [UserInfo]

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -21,6 +21,7 @@ module Lndr.Handler (
     , nickLookupHandler
     , nickSearchHandler
     , friendHandler
+    , friendRequestsHandler
     , addFriendsHandler
     , removeFriendsHandler
     , userHandler

--- a/lndr-backend/src/Lndr/Handler/Friend.hs
+++ b/lndr-backend/src/Lndr/Handler/Friend.hs
@@ -51,7 +51,13 @@ nickSearchHandler nick = do
 friendHandler :: Address -> LndrHandler [UserInfo]
 friendHandler addr = do
     pool <- asks dbConnectionPool
-    liftIO . withResource pool $ Db.lookupFriendsWithNick addr
+    liftIO . withResource pool $ Db.lookupFriends addr
+
+
+friendRequestsHandler :: Address -> LndrHandler [UserInfo]
+friendRequestsHandler address = do
+    pool <- asks dbConnectionPool
+    liftIO . withResource pool $ Db.lookupFriendRequests address
 
 
 userHandler :: Maybe EmailAddress -> Maybe Nick -> LndrHandler UserInfo

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -68,6 +68,7 @@ type LndrAPI =
                :> QueryParam "nick" Nick
                :> Get '[JSON] UserInfo
    :<|> "friends" :> Capture "user" Address :> Get '[JSON] [UserInfo]
+   :<|> "friend_requests" :> Capture "user" Address :> Get '[JSON] [UserInfo]
    :<|> "add_friends" :> Capture "user" Address
                       :> ReqBody '[JSON] [Address]
                       :> PostNoContent '[JSON] NoContent
@@ -104,6 +105,7 @@ server = transactionsHandler
     :<|> photoUploadHandler
     :<|> userHandler
     :<|> friendHandler
+    :<|> friendRequestsHandler
     :<|> addFriendsHandler
     :<|> removeFriendsHandler
     :<|> counterpartiesHandler

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -29,6 +29,7 @@ module Lndr.CLI.Args (
     -- * friend-related requests
     , addFriend
     , getFriends
+    , getFriendRequests
     , removeFriend
     , setProfilePhoto
 

--- a/lndr-cli/src/Lndr/CLI/Args.hs
+++ b/lndr-cli/src/Lndr/CLI/Args.hs
@@ -310,6 +310,12 @@ getFriends url userAddr = do
     HTTP.getResponseBody <$> HTTP.httpJSON req
 
 
+getFriendRequests :: String -> Address -> IO [UserInfo]
+getFriendRequests url userAddr = do
+    req <- HTTP.parseRequest $ url ++ "/friend_requests/" ++ show userAddr
+    HTTP.getResponseBody <$> HTTP.httpJSON req
+
+
 getBalance :: String -> Address -> String -> IO Integer
 getBalance url userAddr currency = do
     req <- HTTP.parseRequest $ url ++ "/balance/" ++ show userAddr ++ "?currency=" ++ currency

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -125,9 +125,18 @@ nickTest = do
     -- user1 adds user2 as a friend
     httpCode <- addFriend testUrl testAddress3 testAddress4
     assertEqual "add friend success" 204 httpCode
-    -- verify that friend has been added
+    -- verify that friend has not been added yet
     friends <- getFriends testUrl testAddress3
-    assertEqual "friend properly added" [UserInfo testAddress4 (Just testNick1)] friends
+    assertEqual "unconfirmed friend properly not included" [] friends
+    -- user2 confirms user1 as a friend
+    httpCode <- addFriend testUrl testAddress4 testAddress3
+    assertEqual "confirm friend success" 204 httpCode
+    -- verify that friend has been added for user1
+    friends <- getFriends testUrl testAddress3
+    assertEqual "confirmed friend properly included for user1" [UserInfo testAddress4 (Just testNick1)] friends
+    -- verify that friend has been added for user2
+    friends <- getFriends testUrl testAddress4
+    assertEqual "confirmed friend properly included for user2" [UserInfo testAddress3 (Just testNick2)] friends
 
     -- user3 removes user4 from friends
     removeFriend testUrl testAddress3 testAddress4

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -125,18 +125,34 @@ nickTest = do
     -- user1 adds user2 as a friend
     httpCode <- addFriend testUrl testAddress3 testAddress4
     assertEqual "add friend success" 204 httpCode
+
     -- verify that friend has not been added yet
     friends <- getFriends testUrl testAddress3
-    assertEqual "unconfirmed friend properly not included" [] friends
+    assertEqual "target user is not yet a friend to the requesting user" [] friends
+
+    -- verify that friend has not been added yet
+    friends <- getFriends testUrl testAddress4
+    assertEqual "requesting user is not yet a friend to the target user" [] friends
+
+    -- verify that user2 has a friend request from user1
+    friends <- getFriendRequests testUrl testAddress4
+    assertEqual "target user has friend request from requesting user" [UserInfo testAddress3 (Just testNick2)] friends
+
+    -- verify that user1 does not have a friend request from user2
+    friends <- getFriendRequests testUrl testAddress3
+    assertEqual "requesting user does not have friend request from target user" [] friends
+
     -- user2 confirms user1 as a friend
     httpCode <- addFriend testUrl testAddress4 testAddress3
-    assertEqual "confirm friend success" 204 httpCode
+    assertEqual "target user confirms friend request" 204 httpCode
+
     -- verify that friend has been added for user1
     friends <- getFriends testUrl testAddress3
-    assertEqual "confirmed friend properly included for user1" [UserInfo testAddress4 (Just testNick1)] friends
+    assertEqual "target user is a friend to the requesting user" [UserInfo testAddress4 (Just testNick1)] friends
+
     -- verify that friend has been added for user2
     friends <- getFriends testUrl testAddress4
-    assertEqual "confirmed friend properly included for user2" [UserInfo testAddress3 (Just testNick2)] friends
+    assertEqual "requesting user is a friend to the target user" [UserInfo testAddress3 (Just testNick2)] friends
 
     -- user3 removes user4 from friends
     removeFriend testUrl testAddress3 testAddress4
@@ -144,6 +160,10 @@ nickTest = do
     -- verify that friend has been removed
     friends <- getFriends testUrl testAddress3
     assertEqual "friend properly removed" [] friends
+
+    -- verify that no friend request is present
+    friends <- getFriendRequests testUrl testAddress3
+    assertEqual "friend request not present for half-confirmed friendship" [] friends
 
     -- EMAIL TESTS
 


### PR DESCRIPTION
Delivers [#151](https://github.com/blockmason/lndr/issues/151).

 * Updated `GET /:user/friends` endpoint to only list mutually confirmed friendships.

 * Added `GET /:user/friend_requests` endpoint, listing inbound friendships which do not have a corresponding outbound friendship.
