### PR TITLE
CLI improvements

### DIFF
--- a/lndr-cli/app/Main.hs
+++ b/lndr-cli/app/Main.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 import           Data.Default
 import qualified Data.Text.Lazy             as LT
 import qualified Dhall
-import           Lndr.CLI.Args
+import           Lndr.CLI.Actions
 import           Lndr.CLI.Config
 import           Network.Ethereum.Web3
 import           System.Console.CmdArgs     hiding (def)

--- a/lndr-cli/lndr-cli.cabal
+++ b/lndr-cli/lndr-cli.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Lndr.CLI.Args
+  exposed-modules:     Lndr.CLI.Actions
+                     , Lndr.CLI.CmdLine
                      , Lndr.CLI.Config
   build-depends:       base >= 4.7 && < 5
                      , base64-bytestring

--- a/lndr-cli/src/Lndr/CLI/Actions.hs
+++ b/lndr-cli/src/Lndr/CLI/Actions.hs
@@ -19,9 +19,6 @@ module Lndr.CLI.Actions (
     , setEmail
     , takenEmail
 
-    -- * gas-related requests
-    , getGasPrice
-
     -- * friend-related requests
     , addFriend
     , getFriends
@@ -155,15 +152,6 @@ getCounterparties :: String -> Address -> IO [Address]
 getCounterparties url address = do
     initReq <- HTTP.parseRequest $ url ++ "/counterparties/" ++ show address
     HTTP.getResponseBody <$> HTTP.httpJSON initReq
-
-
-getGasPrice :: String -> IO Integer
-getGasPrice url = do
-    req <- HTTP.parseRequest $ url ++ "/gas_price"
-    resp <- HTTP.getResponseBody <$> HTTP.httpJSONEither req
-    return $ case resp of
-        Left a  -> -1
-        Right b -> b
 
 
 setNick :: String -> Text -> NickRequest -> IO Int

--- a/lndr-cli/src/Lndr/CLI/CmdLine.hs
+++ b/lndr-cli/src/Lndr/CLI/CmdLine.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings     #-}
+
+module Lndr.CLI.CmdLine (
+      LndrCmd(..)
+    , programModes
+    ) where
+
+import           Data.Text                       (Text)
+import           System.Console.CmdArgs          hiding (def)
+import           System.Console.CmdArgs.Explicit (HelpFormat (..), helpText,
+                                                  modeEmpty)
+
+data LndrCmd = Transactions
+             | Pending
+             | RejectPending
+             | Lend { friend :: Text
+                    , amount :: Integer
+                    , memo   :: Text
+                    }
+             | Borrow { friend :: Text
+                      , amount :: Integer
+                      , memo   :: Text
+                      }
+             | Nick { nick :: Text }
+             | SearchNick { nick :: Text }
+             | GetNonce { friend :: Text }
+             | AddFriend { friend :: Text }
+             | RemoveFriend { friend :: Text }
+             | SetPhoto { photoPath :: String }
+             | Info
+             | Unsubmitted
+             | PendingSettlements
+             | LndrConfig
+             deriving (Show, Data, Typeable)
+
+
+programModes = modes [ Transactions
+                        &= help "List all transactions involving default user in default Lndr UCAC"
+                     , Pending
+                        &= help "List all pending transactions"
+                     , RejectPending
+                        &= help "Start interactive credit rejection procss"
+                     , Lend { friend = "0x8c12aab5ffbe1f95b890f60832002f3bbc6fa4cf" &= typ "<counterparty address>"
+                            , amount = 123 &= typ "<currency units>"
+                            , memo = "default" &= typ "<memo text>"
+                            }
+                        &= help "Submit a unilateral transaction as a creditor"
+                     , Borrow { friend = "0x8c12aab5ffbe1f95b890f60832002f3bbc6fa4cf" &= typ "<counterparty address>"
+                              , amount = 123 &= typ "<currency units>"
+                              , memo = "default" &= typ "<memo text>"
+                              }
+                        &= help "Submit a unilateral transaction as a debtor"
+                     , Nick "aupiff"
+                        &= help "Set a nickname for default user"
+                     , SearchNick "aupiff"
+                        &= help "Find address for a corresponding nickname"
+                     , GetNonce { friend = "0x198e13017d2333712bd942d8b028610b95c363da"
+                                    &= typ "<friend>"
+                                }
+                        &= help "Display nonce between default user and the indicated counterpary addess"
+                     , AddFriend "0x198e13017d2333712bd942d8b028610b95c363da"
+                        &= help "Display nonce between default user and the indicated counterpary addess"
+                     , RemoveFriend "0x198e13017d2333712bd942d8b028610b95c363da"
+                        &= help "Remove a friend with the indicated address\
+                               \ from the default user's friend list"
+                     , SetPhoto { photoPath = "image.jpeg" &= typ "<image file>" }
+                        &= help "Use a particular image file as the default\
+                               \ user's profile photo"
+                     , Unsubmitted
+                        &= help "Prints txs that are in lndr db but not yet on the blockchain"
+                     , Info
+                        &= help "Prints config, nick, and friends"
+                     , PendingSettlements
+                        &= help "List all pending settlements"
+                     , LndrConfig
+                        &= help "Prints config endpoint response"
+                     ] &= help "Lend and borrow money.\nServer URL, default user,\
+                              \ and default ucac must be indicated in configuration file."
+                       &= program "lndr"
+                       &= summary "lndr v0.1"


### PR DESCRIPTION
- improving `lndr` command-line help output
- renaming `getSettlements` to `getPendingSettlements` which is its true function
- removing runModes for server functions which have been removed from the API
- removing useless `queryEthereumPrices` test
- splitting up `Args.hs` into two logical parts, one consisting of actions, another consisting of command line mode and argument definitions