### PR TITLE
🚀 Add docker-compose.yml with enhanced support for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 lndr.conf*
 lndr-server.config
+
+# Referenced in docker-compose.yml for persistence between sessions
+/.docker/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+version: "3"
+services:
+  ethereum:
+    image: blockmason/monothereum:v0.1.0
+    networks:
+    - lndr
+  postgresql:
+    image: postgres:10.3
+    environment:
+      POSTGRES_DB: lndr
+      POSTGRES_USER: lndr
+      POSTGRES_PASSWORD: 4mqKZAV1kxDNrJoKNxF9TmNHSuWkqz7aK5z0L2c+TqV6
+    networks:
+    - lndr
+    volumes:
+    - ./.docker/postgresql/data:/var/lib/postgresql/data
+  schema:
+    image: postgres:10.3
+    depends_on:
+    - postgresql
+    environment:
+      DB_HOST: postgresql
+      DB_PORT: 5432
+      DB_USERNAME: lndr
+      DB_PASSWORD: 4mqKZAV1kxDNrJoKNxF9TmNHSuWkqz7aK5z0L2c+TqV6
+      DB_SCHEMA_FILE: /schema/create_tables.sql
+      DELAY: 4
+    networks:
+    - lndr
+    volumes:
+    - ./lndr-backend/db:/schema
+    command: /schema/bootstrap.sh
+  lndr:
+    build:
+      context: ./
+    image: blockmason/lndr-service:latest
+    depends_on:
+    - ethereum
+    - postgresql
+    - schema
+    environment:
+      DB_HOST: postgresql
+      DB_PORT: 5432
+      DB_NAME: lndr
+      DB_USER: lndr
+      DB_PASSWORD: 4mqKZAV1kxDNrJoKNxF9TmNHSuWkqz7aK5z0L2c+TqV6
+      ETHEREUM_CLIENT_URL: http://ethereum:8545
+    ports:
+    - 9800:80/tcp
+    volumes:
+    - ./:/lndr
+    networks:
+    - lndr
+    command: /lndr/docker-entrypoint.sh delay-start 6
+networks:
+  lndr:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,9 +11,18 @@ lndr_start() {
   lndr-server
 }
 
+lndr_delay() {
+  local DELAY="$1"
+  [ -n "${DELAY}" ] || DELAY="5"
+  sleep "${DELAY}"
+}
+
 case "$1" in
   start)
     lndr_start
+    ;;
+  delay-start)
+    lndr_delay && lndr_start
     ;;
   *)
     exec $*

--- a/lndr-backend/db/bootstrap.sh
+++ b/lndr-backend/db/bootstrap.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+BASE_DIR="$(cd "$(dirname "$0")"; pwd)"
+
+# Set default values wherever necessary
+[ -n "${DELAY}" ] || DELAY="0"
+[ -n "${DB_HOST}" ] || DB_HOST="localhost"
+[ -n "${DB_PORT}" ] || DB_PORT="5432"
+[ -n "${DB_USERNAME}" ] || DB_USERNAME="lndr"
+[ -n "${DB_PASSWORD}" ] || DB_PASSWORD="lndr"
+[ -n "${DB_SCHEMA_FILE}" ] || DB_SCHEMA_FILE="${BASE_DIR}/create_tables.sql"
+
+# Grace period to allow for the database to come online
+sleep "${DELAY}"
+
+# Seed the database with the schema file
+echo "${DB_PASSWORD}" \
+| psql \
+  --host="${DB_HOST}" \
+  --port="${DB_PORT}" \
+  --username="${DB_USERNAME}" \
+  --password \
+  --file="${DB_SCHEMA_FILE}"


### PR DESCRIPTION
Run `docker-compose up --build` to get a local development environment up and running on `http://localhost:9800`. This can be done from a clean checkout of this repo (this repo's **Dockerfile** pulls down binaries from the latest successful `master` build on CircleCI).

 * Persists data between sessions to the local **.docker** directory.
 * Automatically bootstraps the database using **lndr-backend/db/create_tables.sql**.
 * Uses [blockmason/monothereum](https://github.com/blockmason/monothereum) to mock the Ethereum JSON-RPC API.
 * Gets a local development server up and running from scratch very quickly, assuming Docker is already installed.