### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,8 @@
 
 Server, CLI, and UCAC Solidity contracts.
 
-
 [![Travis CI](https://img.shields.io/travis/blockmason/lndr.svg?label=Travis%20CI)](https://travis-ci.org/blockmason/lndr)
 [![CircleCI](https://img.shields.io/circleci/project/github/blockmason/lndr.svg?label=CircleCI)](https://circleci.com/gh/blockmason/lndr)
-
-## API
 
 ## Installation
 
@@ -14,14 +11,13 @@ See [INSTALL.md](INSTALL.md)
 
 ## lndr-backend
 
+The server application that acts as intermediary between lndr clients and the
+Credit Protocol contract on the Ethereum blockchain.
+
 [lndr-backend README](lndr-backend/README.md)
 
 ## lndr-cli
 
+A simple command-line lndr client.
+
 [lndr-cli README](lndr-cli/README.md)
-
-## UCAC contract
-
-LNDR Contract Address: `0x869a8f2c3D22Be392618Ed06C8F548D1D5b5aeD6`
-
-[Lndr.sol README](ucac/README.md)

--- a/lndr-backend/README.md
+++ b/lndr-backend/README.md
@@ -6,44 +6,6 @@ The `lndr-server` executable expects a configuration file to be located at
 `lndr-backend/data/lndr-server.config`. This configuration file is loaded into
 a server's memory at startup.
 
-## Geth node requirements
-
-The server expects a `geth` node to be running at localhost (127.0.0.1)
-accepting rpc calls on port 8545.
-
-The `geth` node must have its coinbase set and unlocked. This primary ethereum
-account is used to pay for transactions.
-
-### Perpetually unlocking a node's primary address (coinbase)
-
-In geth console:
-
-```
-> personal.unlockAccount(address, "password", 300)
-```
-
-From commandline:
-
-```
-geth --unlock "0x407d73d8a49eeb85d32cf465507dd71d507100c1,0,5,e470b1a7d2c9c5c6f03bbaa8fa20db6d404a0c32"
-```
-
-To check if an account is unlocked using the geth console:
-
-```
-> personal.listWallets
-[{
-    accounts: [{
-        address: "0xae9c2ed2209d2228c131cc99569233a5d506770b",
-        url: "..."
-    }],
-    status: "Unlocked",
-    url: "..."
-}]
-```
-
-More information available [here](https://github.com/ethereum/go-ethereum/wiki/Managing-your-accounts)
-
 ## Postgres Requirements
 
 The `lndr-server` executable expects a postgress db server configured with information matching `lndr-backend/data/lndr-server.config`'s parameters. The db should have a schema identical to what is contained at `lndr-backend/db/create_tables.sql`.

--- a/lndr-cli/README.md
+++ b/lndr-cli/README.md
@@ -1,100 +1,43 @@
-# fid-cli
+# lndr-cli
 
-## Example usage
+LNDR client-server-blockchain integration tests are stored in `test/Spec.hs`.
 
-```
-λ fiddy transactions
-
-[]
-
-λ fiddy pending
-
-[]
-
-λ fiddy borrow --me=0x1ab560ad22f10d0882c31e57240d6b7ac0b42d48 --fri end=0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb --amount=45
-
-SubmissionResponse
-    { hash = "0x8d2bce94f02a4cfde797b377802d6a28e1398ea80aa48f0af0f448b5a67fd072"
-    , nonce = 0
-    }
-
-λ fiddy transactions
-
-[]
-
-λ fiddy pending
-
-[
-    ( "0x8d2bce94f02a4cfde797b377802d6a28e1398ea80aa48f0af0f448b5a67fd072"
-    , CreditRecord
-        { creditor = "0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb"
-        , debtor = "0x1ab560ad22f10d0882c31e57240d6b7ac0b42d48"
-        , amount = 45
-        , signature = "0xe474fe2856ca9804edffd890de63ab75752cce19bcf27bd550d2a0bd041ef4873ff06da574196b0e0d5bb5e3315a6ce2b6dde3bbde7755c6de27f6a79e4c822c1c"
-        }
-    )
-]
-
-λ fiddy lend --me=0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb --friend=0x1ab560ad22f10d0882c31e57240d6b7ac0b42d48 --amount=45
-
-SubmissionResponse
-    { hash = "0x8d2bce94f02a4cfde797b377802d6a28e1398ea80aa48f0af0f448b5a67fd072"
-    , nonce = 0
-    }
-
-λ fiddy pending
-
-[]
-
-λ fiddy transactions
-[ IssueCreditLog
-    { ucac = d5ec73eac35fc9dd6c3f440bce314779fed09f60
-    , creditor = 6a362e5cee1cf5a5408ff1e12b0bc546618dffcb
-    , debtor = 1ab560ad22f10d0882c31e57240d6b7ac0b42d48
-    , amount = 45
-    }
-]
-```
-
-## `fiddy` Help Docs
+## `lndr` Help Docs
 
 ```
-stack exec -- fiddy --help
-fiddy v0.1
+lndr --help
+lndr v0.1
 
-fiddy [COMMAND] ... [OPTIONS]
-  Lend and borrow money
+lndr [COMMAND] ... [OPTIONS]
+  Lend and borrow money.
+  Server URL, default user, and default ucac must be indicated in configuration
+  file.
+
+Commands:
+  transactions        List all transactions involving default user in default
+                      Lndr UCAC
+  pending             List all pending transactions
+  rejectpending       Start interactive credit rejection procss
+  lend                Submit a unilateral transaction as a creditor
+  borrow              Submit a unilateral transaction as a debtor
+  nick                Set a nickname for default user
+  searchnick          Find address for a corresponding nickname
+  getnonce            Display nonce between default user and the indicated
+                      counterpary addess
+  addfriend           Display nonce between default user and the indicated
+                      counterpary addess
+  removefriend        Remove a friend with the indicated address from the
+                      default user's friend list
+  setphoto            Use a particular image file as the default user's
+                      profile photo
+  unsubmitted         Prints txs that are in lndr db but not yet on the
+                      blockchain
+  info                Prints config, nick, and friends
+  pendingsettlements  List all pending settlements
+  lndrconfig          Prints config endpoint response
 
 Common flags:
   -? --help             Display help message
   -V --version          Print version information
      --numeric-version  Print just the version number
-
-fiddy transactions [OPTIONS]
-  list all transactions processed by FiD UCAC
-
-fiddy pending [OPTIONS]
-  list all pending transactions
-
-fiddy lend [OPTIONS]
-  submit a unilateral transaction as a creditor
-
-  -m --me=ITEM
-  -f --friend=ITEM
-  -a --amount=INT
-
-fiddy borrow [OPTIONS]
-  submit a unilateral transaction as a debtor
-
-  -m --me=ITEM
-  -f --friend=ITEM
-  -a --amount=INT
 ```
-
-## TODO
-
-- sign transactions instead of depending on server to do it
-- get friends lists from server
-- simplify transactions submission
-- better error handling
-    + validate all input data

--- a/lndr-cli/README.md
+++ b/lndr-cli/README.md
@@ -17,7 +17,7 @@ Commands:
   transactions        List all transactions involving default user in default
                       Lndr UCAC
   pending             List all pending transactions
-  rejectpending       Start interactive credit rejection procss
+  rejectpending       Start interactive credit rejection process
   lend                Submit a unilateral transaction as a creditor
   borrow              Submit a unilateral transaction as a debtor
   nick                Set a nickname for default user

--- a/lndr-cli/README.md
+++ b/lndr-cli/README.md
@@ -23,9 +23,9 @@ Commands:
   nick                Set a nickname for default user
   searchnick          Find address for a corresponding nickname
   getnonce            Display nonce between default user and the indicated
-                      counterpary addess
+                      counterparty addess
   addfriend           Display nonce between default user and the indicated
-                      counterpary addess
+                      counterparty addess
   removefriend        Remove a friend with the indicated address from the
                       default user's friend list
   setphoto            Use a particular image file as the default user's

--- a/lndr-cli/src/Lndr/CLI/CmdLine.hs
+++ b/lndr-cli/src/Lndr/CLI/CmdLine.hs
@@ -41,7 +41,7 @@ programModes = modes [ Transactions
                      , Pending
                         &= help "List all pending transactions"
                      , RejectPending
-                        &= help "Start interactive credit rejection procss"
+                        &= help "Start interactive credit rejection proecss"
                      , Lend { friend = "0x8c12aab5ffbe1f95b890f60832002f3bbc6fa4cf" &= typ "<counterparty address>"
                             , amount = 123 &= typ "<currency units>"
                             , memo = "default" &= typ "<memo text>"

--- a/lndr-cli/src/Lndr/CLI/CmdLine.hs
+++ b/lndr-cli/src/Lndr/CLI/CmdLine.hs
@@ -59,9 +59,9 @@ programModes = modes [ Transactions
                      , GetNonce { friend = "0x198e13017d2333712bd942d8b028610b95c363da"
                                     &= typ "<friend>"
                                 }
-                        &= help "Display nonce between default user and the indicated counterpary addess"
+                        &= help "Display nonce between default user and the indicated counterparty addess"
                      , AddFriend "0x198e13017d2333712bd942d8b028610b95c363da"
-                        &= help "Display nonce between default user and the indicated counterpary addess"
+                        &= help "Display nonce between default user and the indicated counterparty addess"
                      , RemoveFriend "0x198e13017d2333712bd942d8b028610b95c363da"
                         &= help "Remove a friend with the indicated address\
                                \ from the default user's friend list"


### PR DESCRIPTION
- removed "geth node requirements" section from `lndr-backend` README
- removed `fiddy` references from `lndr-cli` README
- de-cluttered top-level README