### PR TITLE
🔧 Auto-publish artifacts to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,15 @@ jobs:
               cp "${file}" "artifacts/${file}"
             fi
           done
-
     - store_artifacts:
         path: artifacts
+    - run:
+        name: Publishing (only on master if version has changed)
+        command: |
+          if [ master = "${CIRCLE_BRANCH}" ]; then
+            if [ -n "${AWS_ACCESS_KEY_ID}" ]; then
+              if [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+                aws s3 cp --acl public-read artifacts/lndr-server "s3://blockmason-artifacts/@blockmason/lndr/${CIRCLE_SHA1}/lndr-server"
+              fi
+            fi
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Obsoletes [blockmason/infrastructure-playbook scripts/lndr.publish.sh](https://github.com/blockmason/infrastructure-playbook/blob/master/scripts/lndr.publish.sh).
Delivers [ENG-57](https://blockmason.atlassian.net/browse/ENG-57). (PR 1 of 2)

> **Very Important:** The project in CircleCI is configured to *not* pass environment variables and secrets to PRs. Because this is a public repo and can be forked by any GitHub user, it is of critical importance that this configuration in CircleCI not be changed. Otherwise, the AWS credentials used for publishing will be leaked. We do have safeguards in place to detect and mitigate the damage that these credentials could cause under these circumstances, but an ounce of prevention is worth a pound of cure, eh?

This PR appends a step to the CircleCI build which publishes the `lndr-server` binary to an S3 bucket for its Ansible role to use.
