### PR TITLE
⬆️ Update CircleCI base image to v1.0.2, for AWS CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~
   docker:
-  - image: blockmason/lndr-circleci:1.0.1
+  - image: blockmason/lndr-circleci:1.0.2
 
 version: 2
 jobs:


### PR DESCRIPTION
Targeting the updated image built from the [lndr-circleci.docker](https://github.com/blockmason/lndr-circleci.docker/commit/492432ab2341765ea5bc73d01e7d8f32abac89ad) repo.