### PR TITLE
Added PAYPAL as settlement denomination type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ lndr-server.config
 
 # Referenced in docker-compose.yml for persistence between sessions
 /.docker/
+/lndr-backend/data/lndr-server.dev.config
+lndr-server
+.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ lndr-server.config
 # Referenced in docker-compose.yml for persistence between sessions
 /.docker/
 /lndr-backend/data/lndr-server.dev.config
-lndr-server
+/lndr-server
 .stack-work/

--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -8,7 +8,7 @@ CREATE TABLE pending_credits (
     memo                CHAR(32),
     signature           CHAR(130),
     ucac                CHAR(40),
-    settlement_currency CHAR(3),
+    settlement_currency CHAR(10),
     created_at          TIMESTAMP DEFAULT now()
 );
 

--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -1,14 +1,15 @@
 CREATE TABLE pending_credits (
-    hash        CHAR(64) PRIMARY KEY,
-    submitter   CHAR(40),
-    nonce       NUMERIC(78),
-    creditor    CHAR(40),
-    debtor      CHAR(40),
-    amount      NUMERIC(78),
-    memo        CHAR(32),
-    signature   CHAR(130),
-    ucac        CHAR(40),
-    created_at  TIMESTAMP DEFAULT now()
+    hash                CHAR(64) PRIMARY KEY,
+    submitter           CHAR(40),
+    nonce               NUMERIC(78),
+    creditor            CHAR(40),
+    debtor              CHAR(40),
+    amount              NUMERIC(78),
+    memo                CHAR(32),
+    signature           CHAR(130),
+    ucac                CHAR(40),
+    settlement_currency CHAR(3),
+    created_at          TIMESTAMP DEFAULT now()
 );
 
 CREATE TABLE verified_credits (

--- a/lndr-backend/db/migrations/2018-07-03T10.00.00Z_add_settlement_currency_to_pending_credits.sql
+++ b/lndr-backend/db/migrations/2018-07-03T10.00.00Z_add_settlement_currency_to_pending_credits.sql
@@ -1,0 +1,2 @@
+ALTER TABLE pending_credits
+ADD COLUMN settlement_currency CHAR(10);

--- a/lndr-backend/src/Lndr/Db/PendingCredits.hs
+++ b/lndr-backend/src/Lndr/Db/PendingCredits.hs
@@ -39,8 +39,6 @@ deletePending hash rejection conn = do
 insertSettlementData :: CreditRecord -> Connection -> IO Int
 insertSettlementData (CreditRecord _ _ _ _ _ _ hash _ _ (Just currency) (Just amount) (Just blocknumber)) conn =
     fromIntegral <$> execute conn "INSERT INTO settlements (hash, amount, currency, blocknumber, verified) VALUES (?,?,?,?,FALSE)" (hash, amount, currency, blocknumber)
--- insertSettlementData (CreditRecord _ _ _ _ _ _ hash _ _ Nothing (Just currency) Nothing) conn =
---     fromIntegral <$> execute conn "INSERT INTO settlements (hash, currency, amount, blocknumber, verified) VALUES (?,?,0,0,FALSE)" (hash, currency)
 insertSettlementData _ _ = return 0
 
 

--- a/lndr-backend/src/Lndr/Db/Types.hs
+++ b/lndr-backend/src/Lndr/Db/Types.hs
@@ -34,12 +34,11 @@ instance FromRow CreditRecord where
                                   <*> ((floor :: Rational -> Integer) <$> field)
                                   <*> field <*> field
                                   <*> ((floor :: Rational -> Integer) <$> field)
-                                  <*> field <*> field <*> field
+                                  <*> field <*> field <*> field <*> field
        remaining <- numFieldsRemaining
        if remaining == 0
-            then return $ baseCredit Nothing Nothing Nothing
+            then return $ baseCredit Nothing Nothing
             else baseCredit <$> (fmap (floor :: Rational -> Integer) <$> field)
-                            <*> field
                             <*> (fmap (floor :: Rational -> Integer) <$> field)
 
 instance FromRow BilateralCreditRecord where
@@ -60,7 +59,7 @@ instance FromRow BilateralCreditRecord where
                             then creditorSignature
                             else debtorSignature
         remaining <- numFieldsRemaining
-        (settlementAmountM, settlementCurrencyM, settlementBlockNumberM, txHashM) <-
+        (settlementCurrencyM, settlementAmountM, settlementBlockNumberM, txHashM) <-
             if remaining == 0
                 then pure (Nothing, Nothing, Nothing, Nothing)
                 else (,,,) <$> (fmap (floor :: Rational -> Integer) <$> field)

--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -48,7 +48,6 @@ instance ToSample ConfigResponse where
 instance ToSample SettlementsResponse where
     toSamples _ = singleSample $ SettlementsResponse [crSigned] [crSettleSigned]
 
-
 instance ToSample CreditRecord where
     toSamples _ = singleSample crSigned
 
@@ -72,6 +71,10 @@ instance ToSample EmailRequest where
 instance ToSample UserInfo where
     toSamples _ = singleSample $
         UserInfo "0x11edd217a875063583dd1b638d16810c5d34d54b" (Just "aupiff")
+
+instance ToSample PayPalRequest where
+    toSamples _ = singleSample $
+        PayPalRequest "0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb" "0x11edd217a875063583dd1b638d16810c5d34d54b" ""
 
 instance ToSample IssueCreditLog where
     toSamples _ = singleSample $

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -16,6 +16,7 @@ module Lndr.Handler (
     , balanceHandler
     , twoPartyBalanceHandler
     , multiSettlementHandler
+    , requestPayPalHandler
 
     -- * Friend Handlers
     , nickHandler

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -17,6 +17,7 @@ module Lndr.Handler.Credit (
     , counterpartiesHandler
     , balanceHandler
     , twoPartyBalanceHandler
+    , requestPayPalHandler
     ) where
 
 import           Control.Concurrent.STM
@@ -87,7 +88,7 @@ submitHandler recordNum signedRecord@(CreditRecord creditor debtor _ memo submit
             nicknameM <- liftIO . withResource pool $ Db.lookupNick submitterAddress
 
             forM_ pushDataM $ \(channelID, platform) -> liftIO $ do
-                responseCode <- sendNotification config (Notification channelID platform nicknameM notifyAction)
+                responseCode <- sendNotification config (Notification channelID platform nicknameM notifyAction )
                 let logMsg = "Notification response (" ++ T.unpack currency ++ "): " ++ show responseCode
                 pushLogStrLn loggerSet . toLogStr $ logMsg
 
@@ -229,7 +230,7 @@ sendRejectionNotification pendingRecord signerAddress = do
     pushDataM <- liftIO . withResource pool $ Db.lookupPushDatumByAddress counterparty
     nicknameM <- liftIO . withResource pool $ Db.lookupNick signerAddress
     forM_ pushDataM $ \(channelID, platform) -> liftIO $ do
-            responseCode <- sendNotification config (Notification channelID platform nicknameM PendingCreditRejection)
+            responseCode <- sendNotification config (Notification channelID platform nicknameM PendingCreditRejection )
             let logMsg =  "Notification response (" ++ T.unpack currency ++ "): " ++ show responseCode
             pushLogStrLn loggerSet . toLogStr $ logMsg
 
@@ -306,3 +307,22 @@ multiSettlementHandler :: [CreditRecord] -> LndrHandler NoContent
 multiSettlementHandler transactions = do
     result <- mapM (uncurry submitHandler) $ zip [0..(length transactions)] transactions
     return $ head result
+
+
+requestPayPalHandler :: PayPalRequest -> LndrHandler NoContent
+requestPayPalHandler (PayPalRequest friend requestor _) = do
+    (ServerState pool configTVar loggerSet) <- ask
+    config <- liftIO $ readTVarIO configTVar
+
+    let attemptToNotify = do
+            pushDataM <- liftIO . withResource pool $ Db.lookupPushDatumByAddress friend
+            nicknameM <- liftIO . withResource pool $ Db.lookupNick requestor
+
+            forM_ pushDataM $ \(channelID, platform) -> liftIO $ do
+                responseCode <- sendNotification config (Notification channelID platform nicknameM RequestPayPal )
+                let logMsg = "Notification response (PayPal Request): " ++ show responseCode
+                pushLogStrLn loggerSet . toLogStr $ logMsg
+
+    attemptToNotify
+    
+    pure NoContent

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -196,7 +196,7 @@ calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ uca
     in cr { settlementAmount = Just $ roundToMegaWei settlementAmountRaw
           , settlementBlocknumber = Just blockNumber
           }
-calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ (Just _) _ _) = cr
+calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ (_) _ _) = cr
 
 
 createBilateralFriendship :: Pool Connection -> Address -> Address -> IO ()
@@ -230,7 +230,7 @@ sendRejectionNotification pendingRecord signerAddress = do
     pushDataM <- liftIO . withResource pool $ Db.lookupPushDatumByAddress counterparty
     nicknameM <- liftIO . withResource pool $ Db.lookupNick signerAddress
     forM_ pushDataM $ \(channelID, platform) -> liftIO $ do
-            responseCode <- sendNotification config (Notification channelID platform nicknameM PendingCreditRejection )
+            responseCode <- sendNotification config (Notification channelID platform nicknameM PendingCreditRejection)
             let logMsg =  "Notification response (" ++ T.unpack currency ++ "): " ++ show responseCode
             pushLogStrLn loggerSet . toLogStr $ logMsg
 

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -163,7 +163,7 @@ createPendingRecord recordNum pool signedRecord = do
 -- incoming record if it already exists
 calculateSettlementCreditRecord :: ServerConfig -> CreditRecord -> CreditRecord
 calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ _ Nothing _) = cr
-calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ ucac _ (Just currency) _) =
+calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ ucac _ (Just "ETH") _) =
     let blockNumber = latestBlockNumber config
         prices = ethereumPrices config
         priceAdjustmentForCents = 100
@@ -195,6 +195,7 @@ calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ uca
     in cr { settlementAmount = Just $ roundToMegaWei settlementAmountRaw
           , settlementBlocknumber = Just blockNumber
           }
+calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ _ (Just _) _) = cr
 
 
 createBilateralFriendship :: Pool Connection -> Address -> Address -> IO ()

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -162,8 +162,8 @@ createPendingRecord recordNum pool signedRecord = do
 -- TODO: change the settlementAmountRaw to use the settlementAmount on the
 -- incoming record if it already exists
 calculateSettlementCreditRecord :: ServerConfig -> CreditRecord -> CreditRecord
-calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ _ Nothing _) = cr
-calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ ucac _ (Just "ETH") _) =
+calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ Nothing _ _) = cr
+calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ ucac (Just "ETH") _ _) =
     let blockNumber = latestBlockNumber config
         prices = ethereumPrices config
         priceAdjustmentForCents = 100
@@ -195,7 +195,7 @@ calculateSettlementCreditRecord config cr@(CreditRecord _ _ amount _ _ _ _ _ uca
     in cr { settlementAmount = Just $ roundToMegaWei settlementAmountRaw
           , settlementBlocknumber = Just blockNumber
           }
-calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ _ (Just _) _) = cr
+calculateSettlementCreditRecord _ cr@(CreditRecord _ _ _ _ _ _ _ _ _ (Just _) _ _) = cr
 
 
 createBilateralFriendship :: Pool Connection -> Address -> Address -> IO ()

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -57,6 +57,7 @@ type LndrAPI =
    :<|> "borrow" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
    :<|> "reject" :> ReqBody '[JSON] RejectRequest :> PostNoContent '[JSON] NoContent
    :<|> "multi_settlement" :> ReqBody '[JSON] [CreditRecord] :> PostNoContent '[JSON] NoContent
+   :<|> "request_paypal" :> ReqBody '[JSON] PayPalRequest :> PostNoContent  '[JSON] NoContent
    :<|> "nonce" :> Capture "p1" Address :> Capture "p2" Address :> Get '[JSON] Nonce
    :<|> "nick" :> ReqBody '[JSON] NickRequest :> PostNoContent '[JSON] NoContent
    :<|> "nick" :> Capture "user" Address :> Get '[JSON] Text
@@ -97,6 +98,7 @@ server = transactionsHandler
     :<|> borrowHandler
     :<|> rejectHandler
     :<|> multiSettlementHandler
+    :<|> requestPayPalHandler
     :<|> nonceHandler
     :<|> nickHandler
     :<|> nickLookupHandler

--- a/lndr-backend/src/Lndr/Signature.hs
+++ b/lndr-backend/src/Lndr/Signature.hs
@@ -73,3 +73,10 @@ instance VerifiableSignature PushRequest where
         stripHexPrefix <$> [ bytesEncode platform
                            , bytesEncode channelID
                            , T.pack (show addr) ]
+
+instance VerifiableSignature PayPalRequest where
+    extractSignature (PayPalRequest _ _ sig) = sig
+
+    generateHash (PayPalRequest friend requestor _) = EU.hashText . T.concat $
+        stripHexPrefix <$> [ T.pack (show friend)
+                           , T.pack (show requestor) ]

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -23,6 +23,7 @@ module Lndr.Types
     , VerifySettlementRequest(..)
     , RejectRequest(..)
     , Nonce(..)
+    , PayPalRequest(..)
 
     -- * push notifications-relatd types
     , PushRequest(..)
@@ -170,6 +171,7 @@ data NotificationAction = NewPendingCredit
                         | CreditConfirmation
                         | PendingCreditRejection
                         | NewFriendRequest
+                        | RequestPayPal
                         deriving Show
 $(deriveJSON defaultOptions ''NotificationAction)
 
@@ -349,3 +351,9 @@ data VerifySettlementRequest = VerifySettlementRequest { verifySettlementRequest
                                                        , verifySettlementRequestSignature :: Signature
                                                        }
 $(deriveJSON (defaultOptions { fieldLabelModifier = over _head toLower . drop 23 }) ''VerifySettlementRequest)
+
+data PayPalRequest = PayPalRequest { friend :: Address
+                                   , requestor :: Address
+                                   , paypalRequestSignature :: Text
+                                   } deriving Show
+$(deriveJSON defaultOptions ''PayPalRequest)

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -114,8 +114,8 @@ data CreditRecord = CreditRecord { creditor              :: Address
                                  , hash                  :: CreditHash
                                  , signature             :: Signature
                                  , ucac                  :: Address
-                                 , settlementAmount      :: Maybe Integer
                                  , settlementCurrency    :: Maybe Text
+                                 , settlementAmount      :: Maybe Integer
                                  , settlementBlocknumber :: Maybe Integer
                                  } deriving (Show, Generic)
 $(deriveJSON (defaultOptions { omitNothingFields = True }) ''CreditRecord)

--- a/lndr-cli/src/Lndr/CLI/Actions.hs
+++ b/lndr-cli/src/Lndr/CLI/Actions.hs
@@ -41,6 +41,7 @@ module Lndr.CLI.Actions (
     , consistencyCheck
     , verifySettlement
     , submitMultiSettlement
+    , requestPayPal
 
     -- * notifications-related requests
     , registerChannel
@@ -434,3 +435,12 @@ consistencyCheck = do
         , hashPair <$> dbCredits \\ blockchainCredits
         , hashPair <$> blockchainCredits \\ dbCredits)
     where hashPair creditLog = (hashCreditLog creditLog, creditLog)
+
+
+requestPayPal :: String -> Text -> PayPalRequest -> IO Int
+requestPayPal url sk paypalRequest = do
+    initReq <- HTTP.parseRequest $ url ++ "/request_paypal"
+    let Right signature = generateSignature paypalRequest sk
+        req = HTTP.setRequestBodyJSON (paypalRequest { paypalRequestSignature = signature }) $
+                HTTP.setRequestMethod "POST" initReq
+    HTTP.getResponseStatusCode <$> HTTP.httpNoBody req

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -29,26 +29,30 @@ import qualified Text.EmailAddress              as Email
 import           System.Directory
 
 testUrl = "http://localhost:7402"
-testPrivkey0 = "7920ca01d3d1ac463dfd55b5ddfdcbb64ae31830f31be045ce2d51a305516a37"
-testPrivkey1 = "bb63b692f9d8f21f0b978b596dc2b8611899f053d68aec6c1c20d1df4f5b6ee2"
-testPrivkey2 = "2f615ea53711e0d91390e97cdd5ce97357e345e441aa95d255094164f44c8652"
-testPrivkey3 = "7d52c3f6477e1507d54a826833169ad169a56e02ffc49a1801218a7d87ca50bd"
-testPrivkey4 = "6aecd44fcb79d4b68f1ee2b2c706f8e9a0cd06b0de4729fe98cfed8886315256"
-testPrivkey5 = "686e245584fdf696abd739c0e66ac6e01fc4c68babee20c7124566e118b2a634"
-testPrivkey6 = "9fd4ab25e1699bb252f4d5c4510a135db34b3adca8baa03194ad5cd6faa13a1d"
-testPrivkey7 = "e8445efa4e3349c3c74fd6689553f93b55aca723115fb777e1e6f4db2a0a82ca"
-testPrivkey8 = "56901d80abc6953d1dc01de2f077b75260f49a3304f665b57ed13514a7e2a2bc"
-testPrivkey9 = "edc63d0e14b29aaa26c7585e962f93abb59bd7d8b01b585e073dc03d052a000b"
-testAddress0 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey0
-testAddress1 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey1
-testAddress2 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey2
-testAddress3 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey3
-testAddress4 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey4
-testAddress5 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey5
-testAddress6 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey6
-testAddress7 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey7
-testAddress8 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey8
-testAddress9 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey9
+testPrivkey0  =  "7920ca01d3d1ac463dfd55b5ddfdcbb64ae31830f31be045ce2d51a305516a37"
+testPrivkey1  =  "bb63b692f9d8f21f0b978b596dc2b8611899f053d68aec6c1c20d1df4f5b6ee2"
+testPrivkey2  =  "2f615ea53711e0d91390e97cdd5ce97357e345e441aa95d255094164f44c8652"
+testPrivkey3  =  "7d52c3f6477e1507d54a826833169ad169a56e02ffc49a1801218a7d87ca50bd"
+testPrivkey4  =  "6aecd44fcb79d4b68f1ee2b2c706f8e9a0cd06b0de4729fe98cfed8886315256"
+testPrivkey5  =  "686e245584fdf696abd739c0e66ac6e01fc4c68babee20c7124566e118b2a634"
+testPrivkey6  =  "9fd4ab25e1699bb252f4d5c4510a135db34b3adca8baa03194ad5cd6faa13a1d"
+testPrivkey7  =  "e8445efa4e3349c3c74fd6689553f93b55aca723115fb777e1e6f4db2a0a82ca"
+testPrivkey8  =  "56901d80abc6953d1dc01de2f077b75260f49a3304f665b57ed13514a7e2a2bc"
+testPrivkey9  =  "edc63d0e14b29aaa26c7585e962f93abb59bd7d8b01b585e073dc03d052a000b"
+testPrivkey10 = "07690ee125a0f79ed899b0f13933885048afd890d5fcb03d988a49fcfd04afc4"
+testPrivkey11 = "7784267bcfad13a4a38fddce9a5ad440ecfa4334a5c068aaac2b2edf6178c80a"
+testAddress0  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey0
+testAddress1  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey1
+testAddress2  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey2
+testAddress3  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey3
+testAddress4  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey4
+testAddress5  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey5
+testAddress6  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey6
+testAddress7  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey7
+testAddress8  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey8
+testAddress9  = textToAddress . userFromSK . LT.fromStrict $ testPrivkey9
+testAddress10 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey10
+testAddress11 = textToAddress . userFromSK . LT.fromStrict $ testPrivkey11
 testSearch = "test"
 testNick1 = "test1"
 testNick2 = "test2"
@@ -93,6 +97,7 @@ tests = [ testGroup "Nicks"
         , testGroup "Credits"
             [ testCase "lend money to friend" basicLendTest
             , testCase "settlement" basicSettlementTest
+            , testCase "PayPal settlement" basicPayPalTest
             ]
         , testGroup "Notifications"
             [ testCase "registerChannel" basicNotificationsTest
@@ -307,7 +312,7 @@ basicSettlementTest = do
     (ucacAddr, ucacAddrKRW, ucacAddrJPY, ucacAddrDKK, ucacAddrCHF, ucacAddrCNY, ucacAddrEUR, ucacAddrAUD, ucacAddrGBP, ucacAddrHKD, ucacAddrCAD, ucacAddrNOK, ucacAddrSEK, ucacAddrNZD, ucacAddrIDR, ucacAddrMYR, ucacAddrSGD, ucacAddrTHB, ucacAddrVND, ucacAddrILS, ucacAddrRUB, ucacAddrTRY) <- loadUcacs
 
     let testAmount = 2939
-        testCredit' = CreditRecord testAddress5 testAddress6 testAmount "settlement" testAddress5 0 "" "" ucacAddr Nothing (Just "ETH") Nothing
+        testCredit' = CreditRecord testAddress5 testAddress6 testAmount "settlement" testAddress5 0 "" "" ucacAddr (Just "ETH") Nothing Nothing
         creditHash = generateHash testCredit'
         testCredit = testCredit' { hash = creditHash }
 
@@ -363,6 +368,64 @@ basicSettlementTest = do
 
     gottenTxHash <- getTxHash testUrl creditHash
     assertEqual "successful txHash retrieval" txHash (addHexPrefix gottenTxHash)
+
+
+basicPayPalTest :: Assertion
+basicPayPalTest = do
+    (ucacAddr, ucacAddrKRW, ucacAddrJPY, ucacAddrDKK, ucacAddrCHF, ucacAddrCNY, ucacAddrEUR, ucacAddrAUD, ucacAddrGBP, ucacAddrHKD, ucacAddrCAD, ucacAddrNOK, ucacAddrSEK, ucacAddrNZD, ucacAddrIDR, ucacAddrMYR, ucacAddrSGD, ucacAddrTHB, ucacAddrVND, ucacAddrILS, ucacAddrRUB, ucacAddrTRY) <- loadUcacs
+
+    let testAmount = 100
+        testCredit' = CreditRecord testAddress10 testAddress11 testAmount "PAYPAL TEST 1" testAddress10 0 "" "" ucacAddrGBP (Just "PAYPAL") Nothing Nothing
+
+        creditHash = generateHash testCredit'
+        testCredit = testCredit' { hash = creditHash }
+
+    -- user1 submits paypal tx to user2
+    httpCode <- submitCredit testUrl testPrivkey10 testCredit
+    assertEqual "initial lend success" 204 httpCode
+
+    -- user1 checks pending transactions
+    creditRecords1 <- checkPending testUrl testAddress10
+    assertEqual "one pending record found for user1" 1 (length creditRecords1)
+
+    -- user2 checks pending transactions
+    creditRecords2 <- checkPending testUrl testAddress11
+    assertEqual "one pending record found for user2" 1 (length creditRecords2)
+
+    -- user2 rejects pending transaction
+    httpCode <- rejectCredit testUrl testPrivkey10 creditHash
+    assertEqual "reject success" 204 httpCode
+
+    -- user2 has 0 pending records post-rejection
+    creditRecords2 <- checkPending testUrl testAddress11
+    assertEqual "zero pending records found for user2" 0 (length creditRecords2)
+
+    -- user1 attempts same credit again
+    httpCode <- submitCredit testUrl testPrivkey10 testCredit
+    assertEqual "PayPal lend success" 204 httpCode
+
+    -- user2 accepts user1's pending credit
+    httpCode <- submitCredit testUrl testPrivkey11 (testCredit { submitter = testAddress11 })
+    assertEqual "PayPal borrow success" 204 httpCode
+
+    -- user1's checks that he has pending credits and two verified credits
+    creditRecords1 <- checkPending testUrl testAddress10
+    assertEqual "zero pending records found for user1" 0 (length creditRecords1)
+
+    verifiedRecords1 <- getTransactions testUrl testAddress10
+    assertEqual "one verified record found for user1" 1 (length verifiedRecords1)
+
+    balance <- getBalance testUrl testAddress10 "GBP"
+    assertEqual "user1's total balance is correct" testAmount balance
+
+    twoPartyBalance <- getTwoPartyBalance testUrl testAddress10 testAddress11 "GBP"
+    assertEqual "user1's two-party balance is correct" testAmount twoPartyBalance
+
+    balance <- getBalance testUrl testAddress11 "GBP"
+    assertEqual "user2's total balance is correct" (-testAmount) balance
+
+    twoPartyBalance <- getTwoPartyBalance testUrl testAddress11 testAddress10 "GBP"
+    assertEqual "user2's two-party balance is correct" (-testAmount) twoPartyBalance
 
 
 basicNotificationsTest :: Assertion
@@ -487,8 +550,8 @@ advancedSettlementTest = do
 
     let testAmount1 = 2939
         testAmount2 = 1039
-        testCredits' = [ ( CreditRecord testAddress9 testAddress0 testAmount1 "advanced settlement 1" testAddress9 0 "" "" ucacAddr Nothing (Just "ETH") Nothing )
-            , ( CreditRecord testAddress0 testAddress9 testAmount2 "advanced settlement 2" testAddress9 1 "" "" ucacAddrJPY Nothing (Just "ETH") Nothing ) ]
+        testCredits' = [ ( CreditRecord testAddress9 testAddress0 testAmount1 "advanced settlement 1" testAddress9 0 "" "" ucacAddr (Just "ETH") Nothing Nothing )
+            , ( CreditRecord testAddress0 testAddress9 testAmount2 "advanced settlement 2" testAddress9 1 "" "" ucacAddrJPY (Just "ETH") Nothing Nothing ) ]
             
         -- creditHash =  testCredit'
         testHashes = fmap generateHash testCredits'
@@ -554,5 +617,5 @@ advancedSettlementTest = do
 
     -- This test passes locally but not in TravisCI
     -- (numDbCredits, numBlockchainCredits, _, _) <- consistencyCheck
-    -- assertEqual "correct number of transactions (7) on blockchain" 7 numBlockchainCredits
-    -- assertEqual "correct number of transactions (7) in db" 7 numDbCredits
+    -- assertEqual "correct number of transactions (8) on blockchain" 8 numBlockchainCredits
+    -- assertEqual "correct number of transactions (8) in db" 8 numDbCredits

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -101,6 +101,7 @@ tests = [ testGroup "Nicks"
             ]
         , testGroup "Notifications"
             [ testCase "registerChannel" basicNotificationsTest
+            , testCase "paypalRequest" requestPayPalTest
             ]
         , testGroup "Authentication"
             [ testCase "nick signing" nickSignTest
@@ -619,3 +620,9 @@ advancedSettlementTest = do
     -- (numDbCredits, numBlockchainCredits, _, _) <- consistencyCheck
     -- assertEqual "correct number of transactions (8) on blockchain" 8 numBlockchainCredits
     -- assertEqual "correct number of transactions (8) in db" 8 numDbCredits
+
+
+requestPayPalTest :: Assertion
+requestPayPalTest = do
+    httpCode1 <- requestPayPal testUrl testPrivkey1 ( PayPalRequest testAddress0 testAddress1 "" )
+    assertEqual "paypal notification request returns 204" 204 httpCode1


### PR DESCRIPTION
This commit adds a pattern to distinguish between ETH settlements and non-ETH settlements. The distinction is now necessary with the addition of PAYPAL settlements. There is not any additional logic needed for PAYPAL settlements.