### PR TITLE
 Added UI notification for PayPal requests

### DIFF
--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -56,3 +56,9 @@ CREATE TABLE push_data (
     channel_id  TEXT UNIQUE,
     platform    TEXT
 );
+
+CREATE TABLE paypal_requests (
+    friend      CHAR(40) PRIMARY KEY,
+    requestor   CHAR(40),
+    created_at  TIMESTAMP DEFAULT now()
+);

--- a/lndr-backend/db/migrations/2018-07-20T10.00.00Z_create_table_paypal_notifications.sql
+++ b/lndr-backend/db/migrations/2018-07-20T10.00.00Z_create_table_paypal_notifications.sql
@@ -1,5 +1,5 @@
 CREATE TABLE paypal_requests (
-    friend                      CHAR(40) PRIMARY KEY,
-    requestor                   CHAR(40),
-    created_at                  TIMESTAMP DEFAULT now()
+    friend      CHAR(40) PRIMARY KEY,
+    requestor   CHAR(40),
+    created_at  TIMESTAMP DEFAULT now()
 );

--- a/lndr-backend/db/migrations/2018-07-20T10.00.00Z_create_table_paypal_notifications.sql
+++ b/lndr-backend/db/migrations/2018-07-20T10.00.00Z_create_table_paypal_notifications.sql
@@ -1,0 +1,5 @@
+CREATE TABLE paypal_requests (
+    friend                      CHAR(40) PRIMARY KEY,
+    requestor                   CHAR(40),
+    created_at                  TIMESTAMP DEFAULT now()
+);

--- a/lndr-backend/src/Lndr/Db.hs
+++ b/lndr-backend/src/Lndr/Db.hs
@@ -48,6 +48,12 @@ module Lndr.Db (
     , insertPushDatum
     , deletePushDatum
     , lookupPushDatumByAddress
+    
+
+    -- * 'paypal_requests' table functions
+    , insertPayPalRequest
+    , deletePayPalRequest
+    , lookupPayPalRequestsByAddress
     ) where
 
 

--- a/lndr-backend/src/Lndr/Db/PendingCredits.hs
+++ b/lndr-backend/src/Lndr/Db/PendingCredits.hs
@@ -75,8 +75,6 @@ deletePayPalRequest r@(PayPalRequest friend requestor sign) conn = do
     fromIntegral <$> execute conn "DELETE FROM paypal_requests WHERE (friend = ? AND requestor = ?)" (friend, requestor)
 
 
-lookupPayPalRequestsByAddress :: Address -> Connection -> IO [(UserInfo, UserInfo)]
+lookupPayPalRequestsByAddress :: Address -> Connection -> IO [PayPalRequestPair]
 lookupPayPalRequestsByAddress userAddr conn = do
-    [(targetNick, targetAddr, requestorAddr, requestorNick)] <- query conn "SELECT targets.nickname, friend, requestor, requestors.nickname FROM paypal_requests LEFT JOIN nicknames requestors ON requestors.address = requestor RIGHT JOIN nicknames targets ON targets.address = friend WHERE (friend = ? OR requestor = ?)" (userAddr, userAddr) :: IO [(Maybe Text, Address, Address, Maybe Text)]
-
-    return $ [(UserInfo targetAddr targetNick), (UserInfo requestorAddr requestorNick)]
+    query conn "SELECT friend, requestor, targets.nickname, requestors.nickname FROM paypal_requests LEFT JOIN nicknames requestors ON requestors.address = requestor LEFT JOIN nicknames targets ON targets.address = friend WHERE (friend = ? OR requestor = ?)" (userAddr, userAddr) :: IO [PayPalRequestPair]

--- a/lndr-backend/src/Lndr/Db/PendingCredits.hs
+++ b/lndr-backend/src/Lndr/Db/PendingCredits.hs
@@ -77,4 +77,4 @@ deletePayPalRequest r@(PayPalRequest friend requestor sign) conn = do
 
 lookupPayPalRequestsByAddress :: Address -> Connection -> IO [PayPalRequestPair]
 lookupPayPalRequestsByAddress userAddr conn = do
-    query conn "SELECT friend, requestor, targets.nickname, requestors.nickname FROM paypal_requests LEFT JOIN nicknames requestors ON requestors.address = requestor LEFT JOIN nicknames targets ON targets.address = friend WHERE (friend = ? OR requestor = ?)" (userAddr, userAddr) :: IO [PayPalRequestPair]
+    query conn "SELECT paypal_requests.friend, paypal_requests.requestor, friends.nickname, requestors.nickname FROM paypal_requests LEFT JOIN nicknames requestors ON requestors.address = requestor LEFT JOIN nicknames friends ON friends.address = friend WHERE (friend = ? OR requestor = ?)" (userAddr, userAddr) :: IO [PayPalRequestPair]

--- a/lndr-backend/src/Lndr/Db/Types.hs
+++ b/lndr-backend/src/Lndr/Db/Types.hs
@@ -22,6 +22,17 @@ instance FromField Address where
 
 instance FromRow UserInfo
 
+instance FromRow PayPalRequestPair where
+    fromRow = do
+        targetAddr <- field
+        requestorAddr <- field
+        targetNick <- field
+        requestorNick <- field
+        let target = UserInfo targetAddr targetNick
+            requestor = UserInfo requestorAddr requestorNick
+
+        return $ PayPalRequestPair target requestor
+        
 instance FromField DevicePlatform where
     fromField f dat = toDevicePlatform <$> fromField f dat
         where toDevicePlatform :: Text -> DevicePlatform

--- a/lndr-backend/src/Lndr/Db/Types.hs
+++ b/lndr-backend/src/Lndr/Db/Types.hs
@@ -24,14 +24,14 @@ instance FromRow UserInfo
 
 instance FromRow PayPalRequestPair where
     fromRow = do
-        targetAddr <- field
+        friendAddr <- field
         requestorAddr <- field
-        targetNick <- field
+        friendNick <- field
         requestorNick <- field
-        let target = UserInfo targetAddr targetNick
+        let friend = UserInfo friendAddr friendNick
             requestor = UserInfo requestorAddr requestorNick
 
-        return $ PayPalRequestPair target requestor
+        return $ PayPalRequestPair friend requestor
         
 instance FromField DevicePlatform where
     fromField f dat = toDevicePlatform <$> fromField f dat

--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -76,6 +76,10 @@ instance ToSample PayPalRequest where
     toSamples _ = singleSample $
         PayPalRequest "0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb" "0x11edd217a875063583dd1b638d16810c5d34d54b" ""
 
+instance ToSample PayPalRequestPair where
+    toSamples _ = singleSample $
+        PayPalRequestPair (UserInfo "0x6a362e5cee1cf5a5408ff1e12b0bc546618dffcb" (Just "Bob")) (UserInfo "0x11edd217a875063583dd1b638d16810c5d34d54b" (Just "Chuck"))
+
 instance ToSample IssueCreditLog where
     toSamples _ = singleSample $
         IssueCreditLog "d5ec73eac35fc9dd6c3f440bce314779fed09f60"

--- a/lndr-backend/src/Lndr/Handler.hs
+++ b/lndr-backend/src/Lndr/Handler.hs
@@ -17,6 +17,8 @@ module Lndr.Handler (
     , twoPartyBalanceHandler
     , multiSettlementHandler
     , requestPayPalHandler
+    , deletePayPalRequestHandler
+    , paypalRequestsLookupHandler
 
     -- * Friend Handlers
     , nickHandler

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -344,7 +344,7 @@ deletePayPalRequestHandler r@(PayPalRequest friend requestor sign) = do
     pure NoContent
 
 
-paypalRequestsLookupHandler :: Address -> LndrHandler [(UserInfo, UserInfo)]
+paypalRequestsLookupHandler :: Address -> LndrHandler [PayPalRequestPair]
 paypalRequestsLookupHandler addr = do
     (ServerState pool configTVar loggerSet) <- ask
     config <- liftIO $ readTVarIO configTVar

--- a/lndr-backend/src/Lndr/Handler/Credit.hs
+++ b/lndr-backend/src/Lndr/Handler/Credit.hs
@@ -18,6 +18,8 @@ module Lndr.Handler.Credit (
     , balanceHandler
     , twoPartyBalanceHandler
     , requestPayPalHandler
+    , deletePayPalRequestHandler
+    , paypalRequestsLookupHandler
     ) where
 
 import           Control.Concurrent.STM
@@ -315,6 +317,8 @@ requestPayPalHandler r@(PayPalRequest friend requestor sign) = do
     (ServerState pool configTVar loggerSet) <- ask
     config <- liftIO $ readTVarIO configTVar
 
+    liftIO . withResource pool $ Db.insertPayPalRequest r
+
     let attemptToNotify = do
             pushDataM <- liftIO . withResource pool $ Db.lookupPushDatumByAddress friend
             nicknameM <- liftIO . withResource pool $ Db.lookupNick requestor
@@ -327,3 +331,22 @@ requestPayPalHandler r@(PayPalRequest friend requestor sign) = do
     attemptToNotify
     
     pure NoContent
+
+
+deletePayPalRequestHandler :: PayPalRequest -> LndrHandler NoContent
+deletePayPalRequestHandler r@(PayPalRequest friend requestor sign) = do
+    unless (Right requestor == recoverSigner r || Right friend == recoverSigner r) $ throwError (err401 {errBody = "Bad signature."})
+    (ServerState pool configTVar loggerSet) <- ask
+    config <- liftIO $ readTVarIO configTVar
+
+    liftIO . withResource pool $ Db.deletePayPalRequest r
+
+    pure NoContent
+
+
+paypalRequestsLookupHandler :: Address -> LndrHandler [(UserInfo, UserInfo)]
+paypalRequestsLookupHandler addr = do
+    (ServerState pool configTVar loggerSet) <- ask
+    config <- liftIO $ readTVarIO configTVar
+
+    liftIO . withResource pool $ Db.lookupPayPalRequestsByAddress addr

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -57,7 +57,9 @@ type LndrAPI =
    :<|> "borrow" :> ReqBody '[JSON] CreditRecord :> PostNoContent '[JSON] NoContent
    :<|> "reject" :> ReqBody '[JSON] RejectRequest :> PostNoContent '[JSON] NoContent
    :<|> "multi_settlement" :> ReqBody '[JSON] [CreditRecord] :> PostNoContent '[JSON] NoContent
-   :<|> "request_paypal" :> ReqBody '[JSON] PayPalRequest :> PostNoContent  '[JSON] NoContent
+   :<|> "request_paypal" :> ReqBody '[JSON] PayPalRequest :> PostNoContent '[JSON] NoContent
+   :<|> "request_paypal" :> Capture "user" Address :> Get '[JSON] [(UserInfo, UserInfo)]
+   :<|> "remove_paypal_request" :> ReqBody '[JSON] PayPalRequest :> PostNoContent '[JSON] NoContent
    :<|> "nonce" :> Capture "p1" Address :> Capture "p2" Address :> Get '[JSON] Nonce
    :<|> "nick" :> ReqBody '[JSON] NickRequest :> PostNoContent '[JSON] NoContent
    :<|> "nick" :> Capture "user" Address :> Get '[JSON] Text
@@ -101,6 +103,8 @@ server = transactionsHandler
     :<|> rejectHandler
     :<|> multiSettlementHandler
     :<|> requestPayPalHandler
+    :<|> paypalRequestsLookupHandler
+    :<|> deletePayPalRequestHandler
     :<|> nonceHandler
     :<|> nickHandler
     :<|> nickLookupHandler

--- a/lndr-backend/src/Lndr/Server.hs
+++ b/lndr-backend/src/Lndr/Server.hs
@@ -58,7 +58,7 @@ type LndrAPI =
    :<|> "reject" :> ReqBody '[JSON] RejectRequest :> PostNoContent '[JSON] NoContent
    :<|> "multi_settlement" :> ReqBody '[JSON] [CreditRecord] :> PostNoContent '[JSON] NoContent
    :<|> "request_paypal" :> ReqBody '[JSON] PayPalRequest :> PostNoContent '[JSON] NoContent
-   :<|> "request_paypal" :> Capture "user" Address :> Get '[JSON] [(UserInfo, UserInfo)]
+   :<|> "request_paypal" :> Capture "user" Address :> Get '[JSON] [PayPalRequestPair]
    :<|> "remove_paypal_request" :> ReqBody '[JSON] PayPalRequest :> PostNoContent '[JSON] NoContent
    :<|> "nonce" :> Capture "p1" Address :> Capture "p2" Address :> Get '[JSON] Nonce
    :<|> "nick" :> ReqBody '[JSON] NickRequest :> PostNoContent '[JSON] NoContent

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -24,6 +24,7 @@ module Lndr.Types
     , RejectRequest(..)
     , Nonce(..)
     , PayPalRequest(..)
+    , PayPalRequestPair(..)
 
     -- * push notifications-relatd types
     , PushRequest(..)
@@ -357,3 +358,8 @@ data PayPalRequest = PayPalRequest { friend :: Address
                                    , paypalRequestSignature :: Text
                                    } deriving Show
 $(deriveJSON defaultOptions ''PayPalRequest)
+
+data PayPalRequestPair = PayPalRequestPair { target :: UserInfo
+                                           , requestor :: UserInfo
+                                           } deriving Show
+$(deriveJSON defaultOptions ''PayPalRequestPair)

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -359,7 +359,7 @@ data PayPalRequest = PayPalRequest { friend :: Address
                                    } deriving Show
 $(deriveJSON defaultOptions ''PayPalRequest)
 
-data PayPalRequestPair = PayPalRequestPair { target :: UserInfo
+data PayPalRequestPair = PayPalRequestPair { friend :: UserInfo
                                            , requestor :: UserInfo
                                            } deriving Show
 $(deriveJSON defaultOptions ''PayPalRequestPair)

--- a/lndr-cli/src/Lndr/CLI/Actions.hs
+++ b/lndr-cli/src/Lndr/CLI/Actions.hs
@@ -467,7 +467,7 @@ deletePayPalRequest url sk paypalRequest = do
     HTTP.getResponseStatusCode <$> HTTP.httpNoBody req
 
 
-retrievePayPalRequests :: String -> Address -> IO [(UserInfo, UserInfo)]
+retrievePayPalRequests :: String -> Address -> IO [PayPalRequestPair]
 retrievePayPalRequests url addr = do
-    req <- HTTP.parseRequest $ url ++ "/request_paypal/" ++ show addr
+    req <- HTTP.parseRequest $ url ++ "/request_paypal/" ++ T.unpack (Addr.toText addr)
     HTTP.getResponseBody <$> HTTP.httpJSON req

--- a/lndr-cli/src/Lndr/CLI/Actions.hs
+++ b/lndr-cli/src/Lndr/CLI/Actions.hs
@@ -42,6 +42,8 @@ module Lndr.CLI.Actions (
     , verifySettlement
     , submitMultiSettlement
     , requestPayPal
+    , retrievePayPalRequests
+    , deletePayPalRequest
 
     -- * notifications-related requests
     , registerChannel
@@ -454,3 +456,18 @@ requestPayPal url sk paypalRequest = do
         req = HTTP.setRequestBodyJSON (paypalRequest { paypalRequestSignature = signature }) $
                 HTTP.setRequestMethod "POST" initReq
     HTTP.getResponseStatusCode <$> HTTP.httpNoBody req
+
+
+deletePayPalRequest :: String -> Text -> PayPalRequest -> IO Int
+deletePayPalRequest url sk paypalRequest = do
+    initReq <- HTTP.parseRequest $ url ++ "/remove_paypal_request"
+    let Right signature = generateSignature paypalRequest sk
+        req = HTTP.setRequestBodyJSON (paypalRequest { paypalRequestSignature = signature }) $
+                HTTP.setRequestMethod "POST" initReq
+    HTTP.getResponseStatusCode <$> HTTP.httpNoBody req
+
+
+retrievePayPalRequests :: String -> Address -> IO [(UserInfo, UserInfo)]
+retrievePayPalRequests url addr = do
+    req <- HTTP.parseRequest $ url ++ "/request_paypal/" ++ show addr
+    HTTP.getResponseBody <$> HTTP.httpJSON req

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -634,8 +634,17 @@ payPalRequestTests = do
     httpCode1 <- requestPayPal testUrl testPrivkey1 ( PayPalRequest testAddress0 testAddress1 "" )
     assertEqual "paypal notification request returns 204" 204 httpCode1
 
-    requests <- retrievePayPalRequests testUrl testAddress0
-    assertEqual "retrieve PayPal requests has length of 1" 1 (length requests)
+    payPalRequests1 <- retrievePayPalRequests testUrl testAddress0
+    assertEqual "user0 PayPal requests has length of 1" 1 (length payPalRequests1)
+
+    payPalRequests2 <- retrievePayPalRequests testUrl testAddress1
+    assertEqual "user1 PayPal requests has length of 1" 1 (length payPalRequests2)
 
     httpCode2 <- deletePayPalRequest testUrl testPrivkey1 ( PayPalRequest testAddress0 testAddress1 "" )
     assertEqual "paypal notification request returns 204" 204 httpCode1
+
+    payPalRequests3 <- retrievePayPalRequests testUrl testAddress0
+    assertEqual "user0 PayPal requests has length of 1" 0 (length payPalRequests3)
+
+    payPalRequests4 <- retrievePayPalRequests testUrl testAddress1
+    assertEqual "user0 PayPal requests has length of 1" 0 (length payPalRequests4)

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -97,7 +97,7 @@ tests = [ testGroup "Nicks"
         , testGroup "Credits"
             [ testCase "lend money to friend" basicLendTest
             , testCase "settlement" basicSettlementTest
-            , testCase "PayPal request notification" requestPayPalTest
+            , testCase "PayPal request notification" payPalRequestTests
             , testCase "PayPal settlement" basicPayPalTest
             ]
         , testGroup "Notifications"
@@ -629,7 +629,13 @@ advancedSettlementTest = do
     -- assertEqual "correct number of transactions (8) in db" 8 numDbCredits
 
 
-requestPayPalTest :: Assertion
-requestPayPalTest = do
+payPalRequestTests :: Assertion
+payPalRequestTests = do
     httpCode1 <- requestPayPal testUrl testPrivkey1 ( PayPalRequest testAddress0 testAddress1 "" )
+    assertEqual "paypal notification request returns 204" 204 httpCode1
+
+    requests <- retrievePayPalRequests testUrl testAddress0
+    assertEqual "retrieve PayPal requests has length of 1" 1 (length requests)
+
+    httpCode2 <- deletePayPalRequest testUrl testPrivkey1 ( PayPalRequest testAddress0 testAddress1 "" )
     assertEqual "paypal notification request returns 204" 204 httpCode1


### PR DESCRIPTION
 1. Problem: When a friend requests to send a PayPal payment, the user received a push notification but not a UI notification. This adds all of the server / DB functionality necessary for the user to see UI notifications and handle them. https://blockmason.atlassian.net/browse/ENG-144
 2. Solution: Create a minor DB that stores the friend and requestor addresses for situations in which a user wants to prompt a friend to connect PayPal so that the friend can be paid. There are POST, GET, and DELETE routes
 3. No trade-offs. This has been tested locally and is working as expected
 4. Prior to merge, the file `lndr-backend/db/migrations/2018-07-20T10.00.00Z_create_table_paypal_notifications.sql` must be run on the prod DB to create the new table