### PR TITLE
Added migration to modify paypal_requests table and updated create_tables.sql

### DIFF
--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -58,7 +58,8 @@ CREATE TABLE push_data (
 );
 
 CREATE TABLE paypal_requests (
-    friend      CHAR(40) PRIMARY KEY,
+    friend      CHAR(40),
     requestor   CHAR(40),
-    created_at  TIMESTAMP DEFAULT now()
+    created_at  TIMESTAMP DEFAULT now(),
+    PRIMARY KEY (friend, requestor)
 );

--- a/lndr-backend/db/migrations/2018-07-26T10.00.00Z_change_paypal_requests_primary_key.sql
+++ b/lndr-backend/db/migrations/2018-07-26T10.00.00Z_change_paypal_requests_primary_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE paypal_requests DROP CONSTRAINT paypal_requests_pkey;
+ALTER TABLE paypal_requests ADD PRIMARY KEY (friend, requestor);


### PR DESCRIPTION
 1. Problem: The Primary Key for paypal_requests should not have been `friend` it should have been `(friend, requestor)` to allow for multiple requests for a single friend, but not from the same requestor. Jira: https://blockmason.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=ENG&modal=detail&selectedIssue=ENG-147
 2. Solution: Run a DB migration to update the paypal_requests table. This can be run on the current production DB without issue.
 3. No concerns
 4. The purpose of this PR is to record the DB change, the real change to the server will come from running the new migration, so there are no blockers to merge.
