### PR TITLE
Removed idDocSubType as SumSub said to omit it

### DIFF
--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -113,7 +113,7 @@ instance ToSample IdentityAddress where
 
 instance ToSample IdentityDocument where
     toSamples _ = singleSample $
-        IdentityDocument "idDocType" "idDocSubType" "country" (Just "file")
+        IdentityDocument "idDocType" "country" (Just "file")
 
 instance ToSample IdentityVerificationInfo where
     toSamples _ = singleSample $
@@ -166,7 +166,7 @@ instance ToSample IdentityVerificationResponse where
 
 instance ToSample VerificationMetaData where
     toSamples _ = singleSample $
-        VerificationMetaData "PASSPORT" "FRONT_SIDE" "USA"
+        VerificationMetaData "PASSPORT" "USA"
         
 instance ToSample ProfilePhotoRequest where
     toSamples _ = singleSample $ ProfilePhotoRequest "2394" "239048"

--- a/lndr-backend/src/Lndr/IdentityVerification.hs
+++ b/lndr-backend/src/Lndr/IdentityVerification.hs
@@ -26,9 +26,9 @@ sendVerificationRequest config reqInfo = do
 
 
 sendVerificationDocument :: LoggerSet -> ServerConfig -> Text -> IdentityDocument -> IO IdentityDocument
-sendVerificationDocument loggerSet config sumsubId idenDoc@(IdentityDocument idDocType idDocSubType country (Just file)) = do
+sendVerificationDocument loggerSet config sumsubId idenDoc@(IdentityDocument idDocType country (Just file)) = do
     let content = B64.decodeLenient $ TE.encodeUtf8 file
-        metadata = (VerificationMetaData idDocType idDocSubType country)
+        metadata = (VerificationMetaData idDocType country)
   
     -- pushLogStrLn loggerSet . toLogStr $ metadata
 

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -405,7 +405,6 @@ data IdentityAddress = IdentityAddress { street :: Text
 $(deriveJSON defaultOptions ''IdentityAddress)
 
 data IdentityDocument = IdentityDocument { idDocType :: Text
-                                         , idDocSubType :: Text
                                          , country :: Text
                                          , file :: Maybe Text
                                          } deriving Show
@@ -487,7 +486,6 @@ data VerificationStatusEntry = VerificationStatusEntry { user :: Address
 $(deriveJSON defaultOptions ''VerificationStatusEntry)
 
 data VerificationMetaData = VerificationMetaData { idDocType :: Text
-                                         , idDocSubType :: Text
                                          , country :: Text
                                          } deriving Show
 $(deriveJSON defaultOptions ''VerificationMetaData)


### PR DESCRIPTION
 1. Problem: SumSub has said that the field `idDocSubType` should be removed
 2. Solution: Remove the field. Confirmed that this was working correctly on an E2E test run locally
 3. No concerns
 4. No blockers
