### PR TITLE
Allow a single user to have multiple channel ids 345325d

### DIFF
--- a/lndr-backend/db/create_tables.sql
+++ b/lndr-backend/db/create_tables.sql
@@ -52,8 +52,8 @@ CREATE TABLE nicknames (
 );
 
 CREATE TABLE push_data (
-    address     CHAR(40) PRIMARY KEY,
-    channel_id  TEXT UNIQUE,
+    channel_id  CHAR(36) PRIMARY KEY,
+    address     CHAR(40),
     platform    TEXT
 );
 

--- a/lndr-backend/db/migrations/2018-10-08T10.00.00Z_change_push_data_pk.sql
+++ b/lndr-backend/db/migrations/2018-10-08T10.00.00Z_change_push_data_pk.sql
@@ -1,2 +1,6 @@
+ALTER TABLE push_data ADD COLUMN new_channel_id CHAR(36);
+UPDATE push_data SET new_channel_id = channel_id;
+ALTER TABLE push_data DROP COLUMN channel_id;
+ALTER TABLE push_data RENAME COLUMN new_channel_id TO channel_id;
 ALTER TABLE push_data DROP CONSTRAINT push_data_pkey;
 ALTER TABLE push_data ADD PRIMARY KEY (channel_id);

--- a/lndr-backend/db/migrations/2018-10-08T10.00.00Z_change_push_data_pk.sql
+++ b/lndr-backend/db/migrations/2018-10-08T10.00.00Z_change_push_data_pk.sql
@@ -1,0 +1,2 @@
+ALTER TABLE push_data DROP CONSTRAINT push_data_pkey;
+ALTER TABLE push_data ADD PRIMARY KEY (channel_id);

--- a/lndr-backend/src/Lndr/Db/PushData.hs
+++ b/lndr-backend/src/Lndr/Db/PushData.hs
@@ -11,7 +11,7 @@ import           Network.Ethereum.Web3
 
 insertPushDatum :: Address -> Text -> Text -> Connection -> IO Int
 insertPushDatum addr channelID platform conn = fromIntegral <$>
-    execute conn "INSERT INTO push_data (address, channel_id, platform) VALUES (?,?,?) ON CONFLICT (address) DO UPDATE SET (channel_id, platform) = (EXCLUDED.channel_id, EXCLUDED.platform)" (addr, channelID, platform)
+    execute conn "INSERT INTO push_data (channel_id, address, platform) VALUES (?,?,?) ON CONFLICT (channel_id) DO UPDATE SET (address, platform) = (EXCLUDED.address, EXCLUDED.platform)" (channelID, addr, platform)
 
 
 lookupPushDatumByAddress :: Address -> Connection -> IO (Maybe (Text, DevicePlatform))

--- a/lndr-cli/test/Spec.hs
+++ b/lndr-cli/test/Spec.hs
@@ -444,6 +444,15 @@ basicNotificationsTest = do
     httpCode <- registerChannel testUrl testPrivkey1 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios" testAddress1 "")
     assertEqual "register channel success" 204 httpCode
 
+    httpCode <- registerChannel testUrl testPrivkey1 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios" testAddress1 "")
+    assertEqual "able to register twice with the same address and device" 204 httpCode
+
+    httpCode <- registerChannel testUrl testPrivkey2 (PushRequest "31279004-103e-4ba8-b4bf-65eb3eb81859" "ios" testAddress2 "")
+    assertEqual "able to register device with a different user" 204 httpCode
+
+    httpCode <- registerChannel testUrl testPrivkey2 (PushRequest "79312004-103e-4ba8-b4bf-65eb3eb59818" "android" testAddress2 "")
+    assertEqual "able to register user with a different device" 204 httpCode
+
 
 deleteNotificationsTest :: Assertion
 deleteNotificationsTest = do
@@ -476,7 +485,7 @@ multiSettlementLendTest = do
             , ( CreditRecord testAddress8 testAddress7 testAmount2 "multiSettlement good 2" testAddress7 1 "" "" ucacAddrJPY Nothing Nothing Nothing ) ]
         badTestCredits' = [ ( CreditRecord testAddress7 testAddress7 testAmount1 "multiSettlement bad 1" testAddress7 0 "" "" ucacAddr Nothing Nothing Nothing )
             , ( CreditRecord testAddress7 testAddress7 testAmount2 "multiSettlement bad 2" testAddress7 1 "" "" ucacAddrJPY Nothing Nothing Nothing ) ]
-            
+
         -- creditHash =  testCredit'
         testHashes = fmap generateHash testCredits'
         testCredits = fmap (\credit -> credit { hash = generateHash credit } ) testCredits'
@@ -569,7 +578,7 @@ advancedSettlementTest = do
         testAmount2 = 1039
         testCredits' = [ ( CreditRecord testAddress9 testAddress0 testAmount1 "advanced settlement 1" testAddress9 0 "" "" ucacAddr (Just "ETH") Nothing Nothing )
             , ( CreditRecord testAddress0 testAddress9 testAmount2 "advanced settlement 2" testAddress9 1 "" "" ucacAddrJPY (Just "ETH") Nothing Nothing ) ]
-            
+
         -- creditHash =  testCredit'
         testHashes = fmap generateHash testCredits'
         testCredits = fmap (\credit -> credit { hash = generateHash credit } ) testCredits'
@@ -589,7 +598,7 @@ advancedSettlementTest = do
      -- user6 accepts user5's pending settlement credit
     httpCode <- submitMultiSettlement testUrl testPrivkey0 testCredits2
     assertEqual "borrow (settle) success" 204 httpCode
-   
+
     (SettlementsResponse pendingSettlements bilateralPendingSettlements) <- getPendingSettlements testUrl testAddress9
     assertEqual "post-confirmation: get pending settlements success" 0 (length pendingSettlements)
     assertEqual "post-confirmation: get bilateral pending settlements success" 2 (length bilateralPendingSettlements)


### PR DESCRIPTION
 1. Jira: https://blockmason.atlassian.net/browse/LNDR-8
 2. Problem: The Lndr DB has a unique constraint on channel_id in the push_data table that throws a 500 error when a user tries to register a new channel_id
 3. Solution: Change the primary key of the push_data table and modify the upsert query to allow a user to have multiple channel_ids.
 4. No concerns
 5. Before merging, the new migration file should be run: `lndr-backend/db/migrations/2018-10-08T10.00.00Z_change_push_data_pk.sql`