### PR TITLE
Updated the KYC request body object to move the idDocs value up a level and make it a Maybe

### DIFF
--- a/lndr-backend/src/Lndr/Docs.hs
+++ b/lndr-backend/src/Lndr/Docs.hs
@@ -117,7 +117,7 @@ instance ToSample IdentityDocument where
 
 instance ToSample IdentityVerificationInfo where
     toSamples _ = singleSample $
-        IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" [] []
+        IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" []
 
 instance ToSample RequiredIdentityDocuments where
     toSamples _ = singleSample $
@@ -131,9 +131,10 @@ instance ToSample IdentityVerificationRequest where
     toSamples _ = singleSample $
         IdentityVerificationRequest (fromJust $ Email.emailAddressFromText "email@email.com")
             "0x11edd217a875063583dd1b638d16810c5d34d54b"
-            (IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" [] [] )
+            (IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" [])
             (RequiredIdentityDocuments "country" [] )
             "0x457b0db63b83199f305ef29ba2d7678820806d98abbe3f6aafe015957ecfc5892368b4432869830456c335ade4f561603499d0216cda3af7b6b6cadf6f273c101b"
+            Nothing
 
 instance ToSample IdentityStatusReview where
     toSamples _ = singleSample $
@@ -160,7 +161,7 @@ instance ToSample VerificationStatusEntry where
 instance ToSample IdentityVerificationResponse where
     toSamples _ = singleSample $
         IdentityVerificationResponse "id" "createdAt" "inspectionId" "clientId" "jobId" "0x11edd217a875063583dd1b638d16810c5d34d54b"
-        (IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" [] [] )
+        (IdentityVerificationInfo "country" "firstName" "middleName" "lastName" "phone" "dob" "nationality" [])
         (fromJust $ Email.emailAddressFromText "email@email.com") "env"
         (RequiredIdentityDocuments "country" [] )
 

--- a/lndr-backend/src/Lndr/IdentityVerification.hs
+++ b/lndr-backend/src/Lndr/IdentityVerification.hs
@@ -17,10 +17,11 @@ import qualified Network.HTTP.Client.MultipartFormData as LM
 import           System.Log.FastLogger
 
 sendVerificationRequest :: ServerConfig -> IdentityVerificationRequest -> IO IdentityVerificationResponse
-sendVerificationRequest config reqInfo = do
+sendVerificationRequest config reqInfo@(IdentityVerificationRequest _ _ _ _ _ idDocs) = do
+    let newReqInfo = reqInfo { idDocs = Nothing }
     initReq <- HTTP.parseRequest $ (sumsubApiUrl config) ++ "/resources/applicants?key=" ++ (sumsubApiKey config)
     let req = HTTP.addRequestHeader HTTP.hAccept acceptContent $
-                    HTTP.setRequestBodyJSON reqInfo $ HTTP.setRequestMethod "POST" initReq
+                    HTTP.setRequestBodyJSON newReqInfo $ HTTP.setRequestMethod "POST" initReq
     HTTP.getResponseBody <$> HTTP.httpJSON req
     where acceptContent = "application/json"
 

--- a/lndr-backend/src/Lndr/Signature.hs
+++ b/lndr-backend/src/Lndr/Signature.hs
@@ -82,9 +82,9 @@ instance VerifiableSignature PayPalRequest where
                            , T.pack (show requestor) ]
 
 instance VerifiableSignature IdentityVerificationRequest where
-    extractSignature (IdentityVerificationRequest _ _ _ _ sig) = sig
+    extractSignature (IdentityVerificationRequest _ _ _ _ sig _) = sig
 
-    generateHash (IdentityVerificationRequest email externalUserId info _ _ ) = EU.hashText . T.concat $
+    generateHash (IdentityVerificationRequest email externalUserId info _ _ _) = EU.hashText . T.concat $
         stripHexPrefix <$> [ T.pack (show externalUserId) ]
 
 instance VerifiableSignature VerificationStatusRequest where

--- a/lndr-backend/src/Lndr/Types.hs
+++ b/lndr-backend/src/Lndr/Types.hs
@@ -429,7 +429,6 @@ data IdentityVerificationInfo = IdentityVerificationInfo { country :: Text
                                            , dob :: Text
                                            , nationality :: Text
                                            , addresses :: [IdentityAddress]
-                                           , idDocs :: [IdentityDocument]
                                            } deriving Show
 $(deriveJSON defaultOptions ''IdentityVerificationInfo)
 
@@ -438,6 +437,7 @@ data IdentityVerificationRequest = IdentityVerificationRequest { email :: EmailA
                                            , info :: IdentityVerificationInfo
                                            , requiredIdDocs :: RequiredIdentityDocuments
                                            , identitySignature :: Signature
+                                           , idDocs :: Maybe [IdentityDocument]
                                            } deriving Show
 $(deriveJSON defaultOptions ''IdentityVerificationRequest)
 


### PR DESCRIPTION
This should be the final PR. The SumSub team has reviewed and confirmed that the API is working correctly.

1. Problem: the JSON being passed for KYC included the idDocs array. This array is used to create the accounts, but should not be passed to SumSub.
2. Solution: move the idDocs property up a level and make it nullable (Haskell Maybe). Then when creating a KYC user, set the idDocs property to Nothing
3. Concerns: none
4. Blockers: none